### PR TITLE
fix: bandit model version in tests

### DIFF
--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -163,7 +163,7 @@ describe('EppoClient Bandits E2E test', () => {
       expect(banditEvent.action).toBe('adidas');
       expect(banditEvent.actionProbability).toBeCloseTo(0.099);
       expect(banditEvent.optimalityGap).toBe(7.1);
-      expect(banditEvent.modelVersion).toBe('v123');
+      expect(banditEvent.modelVersion).toBe('123');
       expect(banditEvent.subjectNumericAttributes).toStrictEqual({ age: 25 });
       expect(banditEvent.subjectCategoricalAttributes).toStrictEqual({
         country: 'USA',

--- a/src/configuration-requestor.spec.ts
+++ b/src/configuration-requestor.spec.ts
@@ -141,7 +141,7 @@ describe('ConfigurationRequestor', () => {
       const bannerBandit = banditModelStore.get('banner_bandit');
       expect(bannerBandit?.banditKey).toBe('banner_bandit');
       expect(bannerBandit?.modelName).toBe('falcon');
-      expect(bannerBandit?.modelVersion).toBe('v123');
+      expect(bannerBandit?.modelVersion).toBe('123');
       const bannerModelData = bannerBandit?.modelData;
       expect(bannerModelData?.gamma).toBe(1);
       expect(bannerModelData?.defaultActionScore).toBe(0);


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

`"modelVersion": "v123",` became `"modelVersion": "123",` in https://github.com/Eppo-exp/sdk-test-data/pull/71

This updates the tests to match this format so they pass again

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
