### PR TITLE
Selki/ff 3514 bandit parameters polling only when needed

### DIFF
--- a/src/configuration-requestor.spec.ts
+++ b/src/configuration-requestor.spec.ts
@@ -203,5 +203,13 @@ describe('ConfigurationRequestor', () => {
       await configurationRequestor.fetchAndStoreConfigurations();
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('Requests bandits only when model versions are different', async () => {
+      await configurationRequestor.fetchAndStoreConfigurations();
+      expect(fetchSpy).toHaveBeenCalledTimes(2); // Once for UFC, another for bandits
+
+      await configurationRequestor.fetchAndStoreConfigurations();
+      expect(fetchSpy).toHaveBeenCalledTimes(3); // Once just for UFC, bandits should be skipped
+    });
   });
 });

--- a/src/configuration-requestor.ts
+++ b/src/configuration-requestor.ts
@@ -51,9 +51,6 @@ export default class ConfigurationRequestor {
         format: configResponse.format,
       });
 
-      if (!this.banditModelConfigurationStore) {
-        throw new Error('Bandit parameters fetched but no bandit configuration store provided');
-      }
       if (
         this.requiresBanditModelConfigurationStoreUpdate(
           this.banditModelVersions,
@@ -99,13 +96,9 @@ export default class ConfigurationRequestor {
       (banditReference: BanditReference) => banditReference.modelVersion,
     );
 
-    referencedModelVersions.forEach((modelVersion) => {
-      if (!currentBanditModelVersions.includes(modelVersion)) {
-        return false;
-      }
-    });
-
-    return true;
+    return !referencedModelVersions.every((modelVersion) =>
+      currentBanditModelVersions.includes(modelVersion),
+    );
   }
 
   private indexBanditVariationsByFlagKey(

--- a/src/configuration-requestor.ts
+++ b/src/configuration-requestor.ts
@@ -1,7 +1,14 @@
 import { IConfigurationStore } from './configuration-store/configuration-store';
 import { hydrateConfigurationStore } from './configuration-store/configuration-store-utils';
 import { IHttpClient } from './http-client';
-import { BanditVariation, BanditParameters, Flag } from './interfaces';
+import {
+  BanditVariation,
+  BanditParameters,
+  Flag,
+  BanditReference,
+} from './interfaces';
+
+type Entry = Flag | BanditVariation[] | BanditParameters;
 
 // Requests AND stores flag configurations
 export default class ConfigurationRequestor {
@@ -77,7 +84,7 @@ export default class ConfigurationRequestor {
       throw new Error('Bandit parameters fetched but no bandit configuration store provided');
     }
     const referencedModelVersions = Object.values(banditReferences).map(
-      (banditReference: BanditReference) => banditReference.modelVersion
+      (banditReference: BanditReference) => banditReference.modelVersion,
     );
 
     const banditModelVersionsInStore = this.getLoadedBanditModelVersions(

--- a/src/configuration-requestor.ts
+++ b/src/configuration-requestor.ts
@@ -65,8 +65,8 @@ export default class ConfigurationRequestor {
             createdAt: configResponse.createdAt,
             format: configResponse.format,});
 
-          this.setBanditModelVersions(
-            this.getLoadedBanditModelVersionsFromStore(this.banditModelConfigurationStore),
+          this.banditModelVersions = this.getLoadedBanditModelVersionsFromStore(
+            this.banditModelConfigurationStore,
           );
         }
       }
@@ -82,10 +82,6 @@ export default class ConfigurationRequestor {
     return Object.values(banditModelConfigurationStore.entries()).map(
       (banditParam: BanditParameters) => banditParam.modelVersion,
     );
-  }
-
-  private setBanditModelVersions(modelVersions: string[]) {
-    this.banditModelVersions = modelVersions;
   }
 
   private requiresBanditModelConfigurationStoreUpdate(

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -2,6 +2,7 @@ import ApiEndpoints from './api-endpoints';
 import { IPrecomputedConfigurationResponse } from './configuration';
 import {
   BanditParameters,
+  BanditReference,
   BanditVariation,
   Environment,
   Flag,
@@ -36,6 +37,7 @@ export interface IUniversalFlagConfigResponse {
   environment: Environment;
   flags: Record<string, Flag>;
   bandits: Record<string, BanditVariation[]>;
+  banditReferences: Record<string, BanditReference>;
 }
 
 export interface IBanditParametersResponse {

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -36,7 +36,6 @@ export interface IUniversalFlagConfigResponse {
   format: FormatEnum;
   environment: Environment;
   flags: Record<string, Flag>;
-  bandits: Record<string, BanditVariation[]>;
   banditReferences: Record<string, BanditReference>;
 }
 

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -3,7 +3,6 @@ import { IPrecomputedConfigurationResponse } from './configuration';
 import {
   BanditParameters,
   BanditReference,
-  BanditVariation,
   Environment,
   Flag,
   FormatEnum,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -104,7 +104,7 @@ export interface BanditVariation {
 
 export interface BanditReference {
   modelVersion: string;
-  flagVariation: BanditVariation[];
+  flagVariations: BanditVariation[];
 }
 
 export interface BanditParameters {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -102,6 +102,11 @@ export interface BanditVariation {
   variationValue: string;
 }
 
+export interface BanditReference {
+  modelVersion: string;
+  flagVariation: BanditVariation[];
+}
+
 export interface BanditParameters {
   banditKey: string;
   modelName: string;


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  Requesting bandits only when needed (when modelVersions differ) saves bandwidth! :)

## Description
[//]: # Before requesting new bandits I do a simple comparison of loaded model version vs the newest model version contained in UFC

## How has this been tested?
[//]: # 


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
