### PR TITLE
feat: Add public API for setting event dispatcher

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     'plugin:promise/recommended',
     'plugin:import/recommended',
   ],
-  plugins: ['@typescript-eslint', 'prettier', 'import', 'promise'],
+  plugins: ['@typescript-eslint', 'prettier', 'import', 'promise', 'unused-imports'],
   rules: {
     'prettier/prettier': [
       'warn',
@@ -24,6 +24,7 @@ module.exports = {
     ],
     'import/named': 'off',
     'import/no-unresolved': 'off',
+    'unused-imports/no-unused-imports': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
     'import/order': [
       'warn',

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^6.0.0",
+    "eslint-plugin-unused-imports": "^4.1.4",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "lodash": "^4.17.21",

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -22,6 +22,7 @@ import { EppoValue } from '../eppo_value';
 import { Evaluator, FlagEvaluation, noneResult } from '../evaluator';
 import ArrayBackedNamedEventQueue from '../events/array-backed-named-event-queue';
 import { BoundedEventQueue } from '../events/bounded-event-queue';
+import { EventDispatcherConfig } from '../events/default-event-dispatcher';
 import EventDispatcher from '../events/event-dispatcher';
 import NoOpEventDispatcher from '../events/no-op-event-dispatcher';
 import {
@@ -79,17 +80,8 @@ export interface IContainerExperiment<T> {
   treatmentVariationEntries: Array<T>;
 }
 
-const DEFAULT_EVENT_DISPATCHER_CONFIG = {
-  // TODO: Replace with actual ingestion URL
-  ingestionUrl: 'https://example.com/events',
-  batchSize: 10,
-  flushIntervalMs: 10_000,
-  retryIntervalMs: 5_000,
-  maxRetries: 3,
-};
-
 export default class EppoClient {
-  private readonly eventDispatcher: EventDispatcher;
+  private eventDispatcher: EventDispatcher;
   private readonly assignmentEventsQueue: BoundedEventQueue<IAssignmentEvent> =
     newBoundedArrayEventQueue<IAssignmentEvent>('assignments');
   private readonly banditEventsQueue: BoundedEventQueue<IBanditEvent> =
@@ -150,6 +142,12 @@ export default class EppoClient {
     banditVariationConfigurationStore: IConfigurationStore<BanditVariation[]>,
   ) {
     this.banditVariationConfigurationStore = banditVariationConfigurationStore;
+  }
+
+  /** Sets the EventDispatcher instance to use when tracking events with {@link track}. */
+  // noinspection JSUnusedGlobalSymbols
+  setEventDispatcher(eventDispatcher: EventDispatcher) {
+    this.eventDispatcher = eventDispatcher;
   }
 
   // noinspection JSUnusedGlobalSymbols

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -20,9 +20,7 @@ import {
 import { decodeFlag } from '../decoding';
 import { EppoValue } from '../eppo_value';
 import { Evaluator, FlagEvaluation, noneResult } from '../evaluator';
-import ArrayBackedNamedEventQueue from '../events/array-backed-named-event-queue';
 import { BoundedEventQueue } from '../events/bounded-event-queue';
-import { EventDispatcherConfig } from '../events/default-event-dispatcher';
 import EventDispatcher from '../events/event-dispatcher';
 import NoOpEventDispatcher from '../events/no-op-event-dispatcher';
 import {
@@ -83,9 +81,9 @@ export interface IContainerExperiment<T> {
 export default class EppoClient {
   private eventDispatcher: EventDispatcher;
   private readonly assignmentEventsQueue: BoundedEventQueue<IAssignmentEvent> =
-    newBoundedArrayEventQueue<IAssignmentEvent>('assignments');
+    new BoundedEventQueue<IAssignmentEvent>('assignments');
   private readonly banditEventsQueue: BoundedEventQueue<IBanditEvent> =
-    newBoundedArrayEventQueue<IBanditEvent>('bandit');
+    new BoundedEventQueue<IBanditEvent>('bandit');
   private readonly banditEvaluator = new BanditEvaluator();
   private banditLogger?: IBanditLogger;
   private banditAssignmentCache?: AssignmentCache;
@@ -1142,8 +1140,4 @@ export function checkValueTypeMatch(
     default:
       return false;
   }
-}
-
-function newBoundedArrayEventQueue<T>(name: string): BoundedEventQueue<T> {
-  return new BoundedEventQueue<T>(new ArrayBackedNamedEventQueue<T>(name));
 }

--- a/src/events/bounded-event-queue.ts
+++ b/src/events/bounded-event-queue.ts
@@ -1,25 +1,25 @@
 import { logger } from '../application-logger';
 import { MAX_EVENT_QUEUE_SIZE } from '../constants';
 
+import ArrayBackedNamedEventQueue from './array-backed-named-event-queue';
 import NamedEventQueue from './named-event-queue';
 
 /** A bounded event queue that drops events when it reaches its maximum size. */
 export class BoundedEventQueue<T> implements NamedEventQueue<T> {
   constructor(
-    private readonly queue: NamedEventQueue<T>,
+    readonly name: string,
+    private readonly queue = new Array<T>(),
     private readonly maxSize = MAX_EVENT_QUEUE_SIZE,
   ) {}
 
   length = this.queue.length;
-
-  name = this.queue.name;
 
   splice(count: number): T[] {
     return this.queue.splice(count);
   }
 
   isEmpty(): boolean {
-    return this.queue.isEmpty();
+    return this.queue.length === 0;
   }
 
   [Symbol.iterator](): IterableIterator<T> {
@@ -30,7 +30,7 @@ export class BoundedEventQueue<T> implements NamedEventQueue<T> {
     if (this.queue.length < this.maxSize) {
       this.queue.push(event);
     } else {
-      logger.warn(`Dropping event for queue ${this.queue.name} since the queue is full`);
+      logger.warn(`Dropping event for queue ${this.name} since the queue is full`);
     }
   }
 

--- a/src/events/bounded-event-queue.ts
+++ b/src/events/bounded-event-queue.ts
@@ -4,11 +4,27 @@ import { MAX_EVENT_QUEUE_SIZE } from '../constants';
 import NamedEventQueue from './named-event-queue';
 
 /** A bounded event queue that drops events when it reaches its maximum size. */
-export class BoundedEventQueue<T> {
+export class BoundedEventQueue<T> implements NamedEventQueue<T> {
   constructor(
     private readonly queue: NamedEventQueue<T>,
     private readonly maxSize = MAX_EVENT_QUEUE_SIZE,
   ) {}
+
+  length = this.queue.length;
+
+  name = this.queue.name;
+
+  splice(count: number): T[] {
+    return this.queue.splice(count);
+  }
+
+  isEmpty(): boolean {
+    return this.queue.isEmpty();
+  }
+
+  [Symbol.iterator](): IterableIterator<T> {
+    return this.queue[Symbol.iterator]();
+  }
 
   push(event: T) {
     if (this.queue.length < this.maxSize) {

--- a/src/events/bounded-event-queue.ts
+++ b/src/events/bounded-event-queue.ts
@@ -1,7 +1,6 @@
 import { logger } from '../application-logger';
 import { MAX_EVENT_QUEUE_SIZE } from '../constants';
 
-import ArrayBackedNamedEventQueue from './array-backed-named-event-queue';
 import NamedEventQueue from './named-event-queue';
 
 /** A bounded event queue that drops events when it reaches its maximum size. */

--- a/src/events/default-event-dispatcher.spec.ts
+++ b/src/events/default-event-dispatcher.spec.ts
@@ -2,7 +2,10 @@ import { resolve } from 'eslint-import-resolver-typescript';
 
 import ArrayBackedNamedEventQueue from './array-backed-named-event-queue';
 import BatchEventProcessor from './batch-event-processor';
-import DefaultEventDispatcher, { EventDispatcherConfig } from './default-event-dispatcher';
+import DefaultEventDispatcher, {
+  EventDispatcherConfig,
+  newDefaultEventDispatcher,
+} from './default-event-dispatcher';
 import { Event } from './event-dispatcher';
 import NetworkStatusListener from './network-status-listener';
 
@@ -196,6 +199,23 @@ describe('DefaultEventDispatcher', () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe('newDefaultEventDispatcher', () => {
+    it('should create a new DefaultEventDispatcher with the provided configuration', () => {
+      const networkStatusListener = {
+        isOffline: () => false,
+        onNetworkStatusChange: (callback: (isOffline: boolean) => void) => null as unknown as void,
+        triggerNetworkStatusChange: () => null,
+      };
+      const eventQueue = new ArrayBackedNamedEventQueue('test-queue');
+      const dispatcher = newDefaultEventDispatcher(
+        eventQueue,
+        networkStatusListener,
+        'zCsQuoHJxVPp895.ZWg9MTIzNDU2LmUudGVzdGluZy5lcHBvLmNsb3Vk',
+      );
+      expect(dispatcher).toBeInstanceOf(DefaultEventDispatcher);
     });
   });
 });

--- a/src/events/default-event-dispatcher.spec.ts
+++ b/src/events/default-event-dispatcher.spec.ts
@@ -203,16 +203,21 @@ describe('DefaultEventDispatcher', () => {
   });
 
   describe('newDefaultEventDispatcher', () => {
+    it('should throw if SDK key is invalid', () => {
+      expect(() => {
+        newDefaultEventDispatcher(
+          new ArrayBackedNamedEventQueue('test-queue'),
+          mockNetworkStatusListener,
+          'invalid-sdk-key',
+        );
+      }).toThrow('Unable to parse Event ingestion URL from SDK key');
+    });
+
     it('should create a new DefaultEventDispatcher with the provided configuration', () => {
-      const networkStatusListener = {
-        isOffline: () => false,
-        onNetworkStatusChange: (callback: (isOffline: boolean) => void) => null as unknown as void,
-        triggerNetworkStatusChange: () => null,
-      };
       const eventQueue = new ArrayBackedNamedEventQueue('test-queue');
       const dispatcher = newDefaultEventDispatcher(
         eventQueue,
-        networkStatusListener,
+        mockNetworkStatusListener,
         'zCsQuoHJxVPp895.ZWg9MTIzNDU2LmUudGVzdGluZy5lcHBvLmNsb3Vk',
       );
       expect(dispatcher).toBeInstanceOf(DefaultEventDispatcher);

--- a/src/events/default-event-dispatcher.spec.ts
+++ b/src/events/default-event-dispatcher.spec.ts
@@ -1,5 +1,3 @@
-import { resolve } from 'eslint-import-resolver-typescript';
-
 import ArrayBackedNamedEventQueue from './array-backed-named-event-queue';
 import BatchEventProcessor from './batch-event-processor';
 import DefaultEventDispatcher, {

--- a/src/events/default-event-dispatcher.ts
+++ b/src/events/default-event-dispatcher.ts
@@ -131,7 +131,7 @@ export function newDefaultEventDispatcher(
   sdkKey: string,
   batchSize: number = DEFAULT_EVENT_DISPATCHER_BATCH_SIZE,
   config: Omit<EventDispatcherConfig, 'ingestionUrl'> = DEFAULT_EVENT_DISPATCHER_CONFIG,
-): DefaultEventDispatcher {
+): EventDispatcher {
   const sdkKeyDecoder = new SdkKeyDecoder();
   const ingestionUrl = sdkKeyDecoder.decodeEventIngestionHostName(sdkKey);
   if (!ingestionUrl) {

--- a/src/events/event-delivery.ts
+++ b/src/events/event-delivery.ts
@@ -1,7 +1,7 @@
 import { logger } from '../application-logger';
 
 export default class EventDelivery {
-  constructor(private ingestionUrl: string) {}
+  constructor(private readonly ingestionUrl: string) {}
 
   async deliver(batch: unknown[]): Promise<boolean> {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,12 @@ import {
 import { HybridConfigurationStore } from './configuration-store/hybrid.store';
 import { MemoryStore, MemoryOnlyConfigurationStore } from './configuration-store/memory.store';
 import * as constants from './constants';
-import ArrayBackedNamedEventQueue from './events/array-backed-named-event-queue';
 import BatchEventProcessor from './events/batch-event-processor';
-import DefaultEventDispatcher from './events/default-event-dispatcher';
+import DefaultEventDispatcher, {
+  DEFAULT_EVENT_DISPATCHER_CONFIG,
+  DEFAULT_EVENT_DISPATCHER_BATCH_SIZE,
+  newDefaultEventDispatcher,
+} from './events/default-event-dispatcher';
 import EventDispatcher from './events/event-dispatcher';
 import NamedEventQueue from './events/named-event-queue';
 import NetworkStatusListener from './events/network-status-listener';
@@ -93,9 +96,12 @@ export {
   BanditSubjectAttributes,
   BanditActions,
 
-  // event queue types
+  // event dispatcher types
   NamedEventQueue,
   EventDispatcher,
+  DEFAULT_EVENT_DISPATCHER_CONFIG,
+  DEFAULT_EVENT_DISPATCHER_BATCH_SIZE,
+  newDefaultEventDispatcher,
   BatchEventProcessor,
   NetworkStatusListener,
   DefaultEventDispatcher,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { HybridConfigurationStore } from './configuration-store/hybrid.store';
 import { MemoryStore, MemoryOnlyConfigurationStore } from './configuration-store/memory.store';
 import * as constants from './constants';
 import BatchEventProcessor from './events/batch-event-processor';
+import { BoundedEventQueue } from './events/bounded-event-queue';
 import DefaultEventDispatcher, {
   DEFAULT_EVENT_DISPATCHER_CONFIG,
   DEFAULT_EVENT_DISPATCHER_BATCH_SIZE,
@@ -99,6 +100,7 @@ export {
   // event dispatcher types
   NamedEventQueue,
   EventDispatcher,
+  BoundedEventQueue,
   DEFAULT_EVENT_DISPATCHER_CONFIG,
   DEFAULT_EVENT_DISPATCHER_BATCH_SIZE,
   newDefaultEventDispatcher,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1831,6 +1831,11 @@ eslint-plugin-promise@^6.0.0:
   resolved "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz"
   integrity sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==
 
+eslint-plugin-unused-imports@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz#62ddc7446ccbf9aa7b6f1f0b00a980423cda2738"
+  integrity sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"


### PR DESCRIPTION
Fixes: FF-3604

## Motivation and Context

## Description
This change accomplishes mainly 2 things:

* Provide a public API so that consumers of this library can set an instance of `EventDispatcher` into the `EppoClient`
* Provide default config values for `DefaultEventDispatcher` instance via factory function
* Parse ingestion URL out of SDK key and set it into the config

## How has this been tested?
Wrote tests


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
