### PR TITLE
fix: Do not throw from `newDefaultEventDispatcher` on invalid key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/events/default-event-dispatcher.spec.ts
+++ b/src/events/default-event-dispatcher.spec.ts
@@ -6,6 +6,7 @@ import DefaultEventDispatcher, {
 } from './default-event-dispatcher';
 import { Event } from './event-dispatcher';
 import NetworkStatusListener from './network-status-listener';
+import NoOpEventDispatcher from './no-op-event-dispatcher';
 
 global.fetch = jest.fn();
 
@@ -201,14 +202,13 @@ describe('DefaultEventDispatcher', () => {
   });
 
   describe('newDefaultEventDispatcher', () => {
-    it('should throw if SDK key is invalid', () => {
-      expect(() => {
-        newDefaultEventDispatcher(
-          new ArrayBackedNamedEventQueue('test-queue'),
-          mockNetworkStatusListener,
-          'invalid-sdk-key',
-        );
-      }).toThrow('Unable to parse Event ingestion URL from SDK key');
+    it('should fallback to no-op dispatcher if SDK key is invalid', () => {
+      const eventDispatcher = newDefaultEventDispatcher(
+        new ArrayBackedNamedEventQueue('test-queue'),
+        mockNetworkStatusListener,
+        'invalid-sdk-key',
+      );
+      expect(eventDispatcher).toBeInstanceOf(NoOpEventDispatcher);
     });
 
     it('should create a new DefaultEventDispatcher with the provided configuration', () => {

--- a/src/events/default-event-dispatcher.ts
+++ b/src/events/default-event-dispatcher.ts
@@ -6,6 +6,7 @@ import EventDelivery from './event-delivery';
 import EventDispatcher, { Event } from './event-dispatcher';
 import NamedEventQueue from './named-event-queue';
 import NetworkStatusListener from './network-status-listener';
+import NoOpEventDispatcher from './no-op-event-dispatcher';
 import SdkKeyDecoder from './sdk-key-decoder';
 
 export type EventDispatcherConfig = {
@@ -135,7 +136,10 @@ export function newDefaultEventDispatcher(
   const sdkKeyDecoder = new SdkKeyDecoder();
   const ingestionUrl = sdkKeyDecoder.decodeEventIngestionHostName(sdkKey);
   if (!ingestionUrl) {
-    throw new Error('Unable to parse Event ingestion URL from SDK key');
+    logger.warn(
+      'Unable to parse Event ingestion URL from SDK key, falling back to no-op event dispatcher',
+    );
+    return new NoOpEventDispatcher();
   }
   return new DefaultEventDispatcher(
     new BatchEventProcessor(eventQueue, batchSize),

--- a/src/events/default-event-dispatcher.ts
+++ b/src/events/default-event-dispatcher.ts
@@ -136,7 +136,7 @@ export function newDefaultEventDispatcher(
   const sdkKeyDecoder = new SdkKeyDecoder();
   const ingestionUrl = sdkKeyDecoder.decodeEventIngestionHostName(sdkKey);
   if (!ingestionUrl) {
-    logger.warn(
+    logger.info(
       'Unable to parse Event ingestion URL from SDK key, falling back to no-op event dispatcher',
     );
     return new NoOpEventDispatcher();

--- a/src/events/default-event-dispatcher.ts
+++ b/src/events/default-event-dispatcher.ts
@@ -136,7 +136,7 @@ export function newDefaultEventDispatcher(
   const sdkKeyDecoder = new SdkKeyDecoder();
   const ingestionUrl = sdkKeyDecoder.decodeEventIngestionHostName(sdkKey);
   if (!ingestionUrl) {
-    logger.info(
+    logger.debug(
       'Unable to parse Event ingestion URL from SDK key, falling back to no-op event dispatcher',
     );
     return new NoOpEventDispatcher();


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
This is actually a valid use case for sdk keys created prior to event gateway creation

## Description
Fallback to no-op implementation

## How has this been tested?
Updated tests


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
