### PR TITLE
fix: Add buffer polyfill with `base64url` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,10 +70,12 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
+    "buffer": "npm:@eppo/buffer@6.2.0",
     "js-base64": "^3.7.7",
     "pino": "^8.19.0",
     "semver": "^7.5.4",
     "spark-md5": "^3.0.2",
     "uuid": "^8.3.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,6 +1339,14 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
+"buffer@npm:@eppo/buffer@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@eppo/buffer/-/buffer-6.2.0.tgz#c073617a106ec710e83835edd593ab55ad2b25a1"
+  integrity sha512-3SP9je+cXr2tHRCwG38P862MjjNALoM4/FGR5ciqjTb6xpJpJxHI1mg0ORwn0Shu8Prn6mUpqqzyAxCvszb8uw==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz"


### PR DESCRIPTION
Fixes: FF-3645

## Motivation and Context
Add `buffer` fork polyfill with support for `base64url` encoding.
Code is here https://github.com/Eppo-exp/buffer/tree/add-base64url-support
Source: https://github.com/feross/buffer/pull/314 (once this is merged, we can revert back to the main buffer repo)

## Description
Make sure we polyfill `buffer` for browser environment and it has support for `base64url`.

Thanks @maya-the-mango for reporting and helping with debugging

## How has this been tested?
* Started a new next.js repo and added a dependency on `"@eppo/js-client-sdk": "^3.8.0",`
* Also added resolution to this fork:
```
  "resolutions": {
    "@eppo/js-client-sdk-common": "git+https://github.com/eppo-exp/js-sdk-common#felipecsl--buffer-polyfill"
  }
```

called `init` and verified no errors thrown
