### PR TITLE
fix: Use js-base64 polyfill instead of `Buffer` for browser env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/events/sdk-key-decoder.spec.ts
+++ b/src/events/sdk-key-decoder.spec.ts
@@ -1,12 +1,20 @@
 import SdkKeyDecoder from './sdk-key-decoder';
 
 describe('SdkKeyDecoder', () => {
+  const decoder = new SdkKeyDecoder();
   it('should decode the event ingestion hostname from the SDK key', () => {
-    const decoder = new SdkKeyDecoder();
     const hostname = decoder.decodeEventIngestionHostName(
       'zCsQuoHJxVPp895.ZWg9MTIzNDU2LmUudGVzdGluZy5lcHBvLmNsb3Vk',
     );
     expect(hostname).toEqual('123456.e.testing.eppo.cloud');
+  });
+
+  it('should decode strings with non URL-safe characters', () => {
+    // this is not a really valid ingestion URL, but it's useful for testing the decoder
+    const invalidUrl = 'eh=12+3456/.e.testing.eppo.cloud';
+    const encoded = Buffer.from(invalidUrl).toString('base64url');
+    const hostname = decoder.decodeEventIngestionHostName(`zCsQuoHJxVPp895.${encoded}`);
+    expect(hostname).toEqual('12 3456/.e.testing.eppo.cloud');
   });
 
   it("should return null if the SDK key doesn't contain the event ingestion hostname", () => {

--- a/src/events/sdk-key-decoder.spec.ts
+++ b/src/events/sdk-key-decoder.spec.ts
@@ -18,7 +18,6 @@ describe('SdkKeyDecoder', () => {
   });
 
   it("should return null if the SDK key doesn't contain the event ingestion hostname", () => {
-    const decoder = new SdkKeyDecoder();
     expect(decoder.decodeEventIngestionHostName('zCsQuoHJxVPp895')).toBeNull();
     expect(decoder.decodeEventIngestionHostName('zCsQuoHJxVPp895.xxxxxx')).toBeNull();
   });

--- a/src/events/sdk-key-decoder.ts
+++ b/src/events/sdk-key-decoder.ts
@@ -1,3 +1,5 @@
+import { Base64 } from 'js-base64';
+
 export default class SdkKeyDecoder {
   /**
    * Decodes and returns the event ingestion hostname from the provided Eppo SDK key string.
@@ -7,7 +9,7 @@ export default class SdkKeyDecoder {
     const encodedPayload = sdkKey.split('.')[1];
     if (!encodedPayload) return null;
 
-    const decodedPayload = Buffer.from(encodedPayload, 'base64url').toString('utf-8');
+    const decodedPayload = Base64.decode(encodedPayload);
     const params = new URLSearchParams(decodedPayload);
     return params.get('eh');
   }


### PR DESCRIPTION
## Motivation and Context
Replace usage of `Buffer` with `js-base64` polyfill for browser environment

## Description
It looks like `Base64.decode` is able to parse both flavors of base64-encoded strings (regular and url-safe `'base64url'` encoding), so this is a safe change. The docs also mention that explicitly https://github.com/dankogai/js-base64?tab=readme-ov-file#synopsis
<img width="581" alt="image" src="https://github.com/user-attachments/assets/51b7dee7-ea23-4fa6-90b3-bf2fdea08cf7">


## How has this been tested?
Wrote another test

Related to https://github.com/Eppo-exp/js-client-sdk/pull/115