### PR TITLE
feat: ability to export precomputed assignments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -203,7 +203,7 @@ describe('EppoClient E2E test', () => {
 
     it('skips disabled flags', () => {
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const { precomputed } = client.getPrecomputedAssignments('subject', {});
+      const { precomputed } = JSON.parse(client.getPrecomputedAssignments('subject', {}));
 
       expect(precomputed).toBeTruthy();
       const precomputedFlags = precomputed?.flags ?? {};
@@ -214,7 +214,7 @@ describe('EppoClient E2E test', () => {
 
     it('evaluates and returns assignments', () => {
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const { precomputed } = client.getPrecomputedAssignments('subject', {});
+      const { precomputed } = JSON.parse(client.getPrecomputedAssignments('subject', {}));
 
       expect(precomputed).toBeTruthy();
       const precomputedFlags = precomputed?.flags ?? {};
@@ -226,7 +226,7 @@ describe('EppoClient E2E test', () => {
 
     it('obfuscates assignments', () => {
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const { precomputed } = client.getPrecomputedAssignments('subject', {}, true);
+      const { precomputed } = JSON.parse(client.getPrecomputedAssignments('subject', {}, true));
 
       expect(precomputed).toBeTruthy();
       const precomputedFlags = precomputed?.flags ?? {};

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -204,8 +204,9 @@ describe('EppoClient E2E test', () => {
 
     it('skips disabled flags', () => {
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const flagResults: IPrecomputedFlagsResponse = JSON.parse(
-        client.exportPrecomputedAssignments('subject', {}),
+      const flagResults: IPrecomputedFlagsResponse = client.getPrecomputedAssignments(
+        'subject',
+        {},
       );
 
       const precomputedFlags = flagResults.flags;
@@ -216,8 +217,9 @@ describe('EppoClient E2E test', () => {
 
     it('evaluates and returns assignments', () => {
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const flagResults: IPrecomputedFlagsResponse = JSON.parse(
-        client.exportPrecomputedAssignments('subject', {}),
+      const flagResults: IPrecomputedFlagsResponse = client.getPrecomputedAssignments(
+        'subject',
+        {},
       );
 
       const precomputedFlags = flagResults.flags;
@@ -229,13 +231,18 @@ describe('EppoClient E2E test', () => {
 
     it('obfuscates assignments', () => {
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const flagResults: IPrecomputedFlagsResponse = JSON.parse(
-        client.exportPrecomputedAssignments('subject', {}, true),
+      const flagResults: IPrecomputedFlagsResponse = client.getPrecomputedAssignments(
+        'subject',
+        {},
+        true,
       );
 
       const precomputedFlags = flagResults.flags;
-      const firstFlag = precomputedFlags['76a475dca4e7f11d2b02f3d257225cef']; // flagKey, md5 hashed
-      const secondFlag = precomputedFlags['6783d6010b0c8a6cd388a96caafe9568']; // 'anotherFlag', md5 hashed
+      expect(Object.keys(precomputedFlags)).toContain('76a475dca4e7f11d2b02f3d257225cef'); // flagKey, md5 hashed
+      expect(Object.keys(precomputedFlags)).toContain('6783d6010b0c8a6cd388a96caafe9568'); // 'anotherFlag', md5 hashed
+
+      const firstFlag = precomputedFlags['76a475dca4e7f11d2b02f3d257225cef'];
+      const secondFlag = precomputedFlags['6783d6010b0c8a6cd388a96caafe9568'];
       expect(firstFlag.variationValue).toEqual('dmFyaWF0aW9uLWE='); // 'variation-a' base64 encoded
       expect(secondFlag.variationValue).toEqual('dmFyaWF0aW9uLWI='); // 'variation-b' base64 encoded
     });

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -13,6 +13,7 @@ import {
   validateTestAssignments,
 } from '../../test/testHelpers';
 import { IAssignmentLogger } from '../assignment-logger';
+import { IConfigurationWire } from '../configuration';
 import { IConfigurationStore } from '../configuration-store/configuration-store';
 import { MemoryOnlyConfigurationStore } from '../configuration-store/memory.store';
 import { MAX_EVENT_QUEUE_SIZE, DEFAULT_POLL_INTERVAL_MS, POLL_JITTER_PCT } from '../constants';
@@ -23,7 +24,6 @@ import { AttributeType } from '../types';
 
 import EppoClient, { FlagConfigurationRequestParameters, checkTypeMatch } from './eppo-client';
 import { initConfiguration } from './test-utils';
-import { IConfigurationWire } from '../configuration';
 
 describe('EppoClient E2E test', () => {
   global.fetch = jest.fn(() => {
@@ -265,9 +265,6 @@ describe('EppoClient E2E test', () => {
       const precomputedFlags = precomputedResponse?.flags ?? {};
       expect(Object.keys(precomputedFlags)).toContain('ddc24ede545855b9bbae82cfec6a83a1'); // flagKey, md5 hashed
       expect(Object.keys(precomputedFlags)).toContain('2b439e5a0104d62400dc44c34230f6f2'); // 'anotherFlag', md5 hashed
-
-      const firstFlag = precomputedFlags['ddc24ede545855b9bbae82cfec6a83a1'];
-      const secondFlag = precomputedFlags['2b439e5a0104d62400dc44c34230f6f2'];
 
       const decodedFirstFlag = decodePrecomputedFlag(
         precomputedFlags['ddc24ede545855b9bbae82cfec6a83a1'],

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -220,7 +220,6 @@ describe('EppoClient E2E test', () => {
       const secondFlag = precomputedFlags['anotherFlag'];
       expect(firstFlag.variationValue).toEqual('variation-a');
       expect(secondFlag.variationValue).toEqual('variation-b');
-
     });
   });
 

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -16,6 +16,7 @@ import { IAssignmentLogger } from '../assignment-logger';
 import { IConfigurationStore } from '../configuration-store/configuration-store';
 import { MemoryOnlyConfigurationStore } from '../configuration-store/memory.store';
 import { MAX_EVENT_QUEUE_SIZE, DEFAULT_POLL_INTERVAL_MS, POLL_JITTER_PCT } from '../constants';
+import { decodePrecomputedFlag } from '../decoding';
 import { Flag, ObfuscatedFlag, VariationType } from '../interfaces';
 import { setSaltOverrideForTests } from '../obfuscation';
 import { AttributeType } from '../types';
@@ -249,8 +250,26 @@ describe('EppoClient E2E test', () => {
 
       const firstFlag = precomputedFlags['ddc24ede545855b9bbae82cfec6a83a1'];
       const secondFlag = precomputedFlags['2b439e5a0104d62400dc44c34230f6f2'];
-      expect(firstFlag.variationValue).toEqual('dmFyaWF0aW9uLWE='); // 'variation-a' base64 encoded
-      expect(secondFlag.variationValue).toEqual('dmFyaWF0aW9uLWI='); // 'variation-b' base64 encoded
+
+      const decodedFirstFlag = decodePrecomputedFlag(
+        precomputedFlags['ddc24ede545855b9bbae82cfec6a83a1'],
+      );
+      expect(decodedFirstFlag.flagKey).toEqual('ddc24ede545855b9bbae82cfec6a83a1');
+      expect(decodedFirstFlag.variationType).toEqual(VariationType.STRING);
+      expect(decodedFirstFlag.variationKey).toEqual('a');
+      expect(decodedFirstFlag.variationValue).toEqual('variation-a');
+      expect(decodedFirstFlag.doLog).toEqual(true);
+      expect(decodedFirstFlag.extraLogging).toEqual({});
+
+      const decodedSecondFlag = decodePrecomputedFlag(
+        precomputedFlags['2b439e5a0104d62400dc44c34230f6f2'],
+      );
+      expect(decodedSecondFlag.flagKey).toEqual('2b439e5a0104d62400dc44c34230f6f2');
+      expect(decodedSecondFlag.variationType).toEqual(VariationType.STRING);
+      expect(decodedSecondFlag.variationKey).toEqual('b');
+      expect(decodedSecondFlag.variationValue).toEqual('variation-b');
+      expect(decodedSecondFlag.doLog).toEqual(true);
+      expect(decodedSecondFlag.extraLogging).toEqual({});
     });
   });
 

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -241,6 +241,8 @@ describe('EppoClient E2E test', () => {
       const { precomputed } = JSON.parse(client.getPrecomputedAssignments('subject', {}, true));
 
       expect(precomputed).toBeTruthy();
+      expect(precomputed.salt).toEqual('BzURTg==');
+
       const precomputedFlags = precomputed?.flags ?? {};
       expect(Object.keys(precomputedFlags)).toContain('ddc24ede545855b9bbae82cfec6a83a1'); // flagKey, md5 hashed
       expect(Object.keys(precomputedFlags)).toContain('2b439e5a0104d62400dc44c34230f6f2'); // 'anotherFlag', md5 hashed

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -203,14 +203,21 @@ describe('EppoClient E2E test', () => {
       });
     });
 
+    let client: EppoClient;
+    beforeEach(() => {
+      client = new EppoClient({ flagConfigurationStore: storage });
+    });
+
     afterEach(() => {
       setSaltOverrideForTests(null);
     });
 
     it('skips disabled flags', () => {
-      const client = new EppoClient({ flagConfigurationStore: storage });
       const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {});
-      const { precomputed } = JSON.parse(encodedPrecomputedWire);
+      const { precomputed } = encodedPrecomputedWire;
+      if (!precomputed) {
+        fail('Precomputed data not in Configuration response');
+      }
       const precomputedResponse = JSON.parse(precomputed.response);
 
       expect(precomputedResponse).toBeTruthy();
@@ -221,9 +228,11 @@ describe('EppoClient E2E test', () => {
     });
 
     it('evaluates and returns assignments', () => {
-      const client = new EppoClient({ flagConfigurationStore: storage });
       const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {});
-      const { precomputed } = JSON.parse(encodedPrecomputedWire);
+      const { precomputed } = encodedPrecomputedWire;
+      if (!precomputed) {
+        fail('Precomputed data not in Configuration response');
+      }
       const precomputedResponse = JSON.parse(precomputed.response);
 
       expect(precomputedResponse).toBeTruthy();
@@ -242,9 +251,11 @@ describe('EppoClient E2E test', () => {
         bytes: new Uint8Array([7, 53, 17, 78]),
       });
 
-      const client = new EppoClient({ flagConfigurationStore: storage });
       const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {}, true);
-      const { precomputed } = JSON.parse(encodedPrecomputedWire);
+      const { precomputed } = encodedPrecomputedWire;
+      if (!precomputed) {
+        fail('Precomputed data not in Configuration response');
+      }
       const precomputedResponse = JSON.parse(precomputed.response);
 
       expect(precomputedResponse).toBeTruthy();

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -23,6 +23,7 @@ import { AttributeType } from '../types';
 
 import EppoClient, { FlagConfigurationRequestParameters, checkTypeMatch } from './eppo-client';
 import { initConfiguration } from './test-utils';
+import { IConfigurationWire } from '../configuration';
 
 describe('EppoClient E2E test', () => {
   global.fetch = jest.fn(() => {
@@ -214,7 +215,7 @@ describe('EppoClient E2E test', () => {
 
     it('skips disabled flags', () => {
       const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {});
-      const { precomputed } = encodedPrecomputedWire;
+      const { precomputed } = JSON.parse(encodedPrecomputedWire) as IConfigurationWire;
       if (!precomputed) {
         fail('Precomputed data not in Configuration response');
       }
@@ -229,7 +230,7 @@ describe('EppoClient E2E test', () => {
 
     it('evaluates and returns assignments', () => {
       const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {});
-      const { precomputed } = encodedPrecomputedWire;
+      const { precomputed } = JSON.parse(encodedPrecomputedWire) as IConfigurationWire;
       if (!precomputed) {
         fail('Precomputed data not in Configuration response');
       }
@@ -252,7 +253,7 @@ describe('EppoClient E2E test', () => {
       });
 
       const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {}, true);
-      const { precomputed } = encodedPrecomputedWire;
+      const { precomputed } = JSON.parse(encodedPrecomputedWire) as IConfigurationWire;
       if (!precomputed) {
         fail('Precomputed data not in Configuration response');
       }

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -209,10 +209,12 @@ describe('EppoClient E2E test', () => {
 
     it('skips disabled flags', () => {
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const { precomputed } = JSON.parse(client.getPrecomputedAssignments('subject', {}));
+      const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {});
+      const { precomputed } = JSON.parse(encodedPrecomputedWire);
+      const precomputedResponse = JSON.parse(precomputed.response);
 
-      expect(precomputed).toBeTruthy();
-      const precomputedFlags = precomputed?.flags ?? {};
+      expect(precomputedResponse).toBeTruthy();
+      const precomputedFlags = precomputedResponse?.flags ?? {};
       expect(Object.keys(precomputedFlags)).toContain('anotherFlag');
       expect(Object.keys(precomputedFlags)).toContain(flagKey);
       expect(Object.keys(precomputedFlags)).not.toContain('disabledFlag');
@@ -220,10 +222,12 @@ describe('EppoClient E2E test', () => {
 
     it('evaluates and returns assignments', () => {
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const { precomputed } = JSON.parse(client.getPrecomputedAssignments('subject', {}));
+      const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {});
+      const { precomputed } = JSON.parse(encodedPrecomputedWire);
+      const precomputedResponse = JSON.parse(precomputed.response);
 
-      expect(precomputed).toBeTruthy();
-      const precomputedFlags = precomputed?.flags ?? {};
+      expect(precomputedResponse).toBeTruthy();
+      const precomputedFlags = precomputedResponse?.flags ?? {};
       const firstFlag = precomputedFlags[flagKey];
       const secondFlag = precomputedFlags['anotherFlag'];
       expect(firstFlag.variationValue).toEqual('variation-a');
@@ -239,12 +243,14 @@ describe('EppoClient E2E test', () => {
       });
 
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const { precomputed } = JSON.parse(client.getPrecomputedAssignments('subject', {}, true));
+      const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {}, true);
+      const { precomputed } = JSON.parse(encodedPrecomputedWire);
+      const precomputedResponse = JSON.parse(precomputed.response);
 
-      expect(precomputed).toBeTruthy();
-      expect(precomputed.salt).toEqual('BzURTg==');
+      expect(precomputedResponse).toBeTruthy();
+      expect(precomputedResponse.salt).toEqual('BzURTg==');
 
-      const precomputedFlags = precomputed?.flags ?? {};
+      const precomputedFlags = precomputedResponse?.flags ?? {};
       expect(Object.keys(precomputedFlags)).toContain('ddc24ede545855b9bbae82cfec6a83a1'); // flagKey, md5 hashed
       expect(Object.keys(precomputedFlags)).toContain('2b439e5a0104d62400dc44c34230f6f2'); // 'anotherFlag', md5 hashed
 

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -16,7 +16,6 @@ import { IAssignmentLogger } from '../assignment-logger';
 import { IConfigurationStore } from '../configuration-store/configuration-store';
 import { MemoryOnlyConfigurationStore } from '../configuration-store/memory.store';
 import { MAX_EVENT_QUEUE_SIZE, DEFAULT_POLL_INTERVAL_MS, POLL_JITTER_PCT } from '../constants';
-import { IPrecomputedFlagsResponse } from '../http-client';
 import { Flag, ObfuscatedFlag, VariationType } from '../interfaces';
 import { AttributeType } from '../types';
 
@@ -204,12 +203,10 @@ describe('EppoClient E2E test', () => {
 
     it('skips disabled flags', () => {
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const flagResults: IPrecomputedFlagsResponse = client.getPrecomputedAssignments(
-        'subject',
-        {},
-      );
+      const { precomputed } = client.getPrecomputedAssignments('subject', {});
 
-      const precomputedFlags = flagResults.flags;
+      expect(precomputed).toBeTruthy();
+      const precomputedFlags = precomputed?.flags ?? {};
       expect(Object.keys(precomputedFlags)).toContain('anotherFlag');
       expect(Object.keys(precomputedFlags)).toContain(flagKey);
       expect(Object.keys(precomputedFlags)).not.toContain('disabledFlag');
@@ -217,12 +214,10 @@ describe('EppoClient E2E test', () => {
 
     it('evaluates and returns assignments', () => {
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const flagResults: IPrecomputedFlagsResponse = client.getPrecomputedAssignments(
-        'subject',
-        {},
-      );
+      const { precomputed } = client.getPrecomputedAssignments('subject', {});
 
-      const precomputedFlags = flagResults.flags;
+      expect(precomputed).toBeTruthy();
+      const precomputedFlags = precomputed?.flags ?? {};
       const firstFlag = precomputedFlags[flagKey];
       const secondFlag = precomputedFlags['anotherFlag'];
       expect(firstFlag.variationValue).toEqual('variation-a');
@@ -231,13 +226,10 @@ describe('EppoClient E2E test', () => {
 
     it('obfuscates assignments', () => {
       const client = new EppoClient({ flagConfigurationStore: storage });
-      const flagResults: IPrecomputedFlagsResponse = client.getPrecomputedAssignments(
-        'subject',
-        {},
-        true,
-      );
+      const { precomputed } = client.getPrecomputedAssignments('subject', {}, true);
 
-      const precomputedFlags = flagResults.flags;
+      expect(precomputed).toBeTruthy();
+      const precomputedFlags = precomputed?.flags ?? {};
       expect(Object.keys(precomputedFlags)).toContain('76a475dca4e7f11d2b02f3d257225cef'); // flagKey, md5 hashed
       expect(Object.keys(precomputedFlags)).toContain('6783d6010b0c8a6cd388a96caafe9568'); // 'anotherFlag', md5 hashed
 

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -890,8 +890,8 @@ export default class EppoClient {
     // Evaluate all the enabled flags for the user
     flagKeys.forEach((flagKey) => {
       const flag = this.getFlag(flagKey);
-      if (flag === null || !flag.enabled) {
-        logger.info(`[Eppo SDK] No assigned variation. Flag is disabled: ${flagKey}`);
+      if (!flag) {
+        logger.debug(`[Eppo SDK] No assigned variation. Flag does not exist.`);
         return;
       }
 
@@ -906,7 +906,7 @@ export default class EppoClient {
 
       // allocationKey is set along with variation when there is a result. this check appeases typescript below
       if (!evaluation.variation || !evaluation.allocationKey) {
-        logger.info(`[Eppo SDK] No assigned variation: ${flagKey}`);
+        logger.debug(`[Eppo SDK] No assigned variation: ${flagKey}`);
         return;
       }
 
@@ -935,7 +935,7 @@ export default class EppoClient {
     subjectKey: string,
     subjectAttributes: Attributes = {},
     obfuscated = false,
-  ): ConfigurationWireFormat {
+  ): string {
     const configDetails = this.getConfigDetails();
     let flags = this.getAllAssignments(subjectKey, subjectAttributes);
 
@@ -943,7 +943,7 @@ export default class EppoClient {
       flags = obfuscatePrecomputedFlags(flags);
     }
 
-    return {
+    const configurationBundle: ConfigurationWireFormat = {
       precomputed: {
         obfuscated,
         subjectKey,
@@ -954,6 +954,8 @@ export default class EppoClient {
         format: FormatEnum.PRECOMPUTED,
       },
     };
+
+    return JSON.stringify(configurationBundle, null, 2);
   }
 
   /**

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -941,7 +941,7 @@ export default class EppoClient {
     subjectKey: string,
     subjectAttributes: Attributes = {},
     obfuscated = false,
-  ): string {
+  ): ConfigurationWire {
     const configDetails = this.getConfigDetails();
     const flags = this.getAllAssignments(subjectKey, subjectAttributes);
 
@@ -959,9 +959,7 @@ export default class EppoClient {
           configDetails.configEnvironment,
         );
 
-    const configurationBundle: ConfigurationWire = new ConfigurationWireV1(precomputedConfig);
-
-    return JSON.stringify(configurationBundle, null, 2);
+    return new ConfigurationWireV1(precomputedConfig);
   }
 
   /**

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -917,6 +917,7 @@ export default class EppoClient {
 
       // Transform into a PrecomputedFlag
       flags[flagKey] = {
+        flagKey,
         allocationKey: evaluation.allocationKey,
         doLog: evaluation.doLog,
         extraLogging: evaluation.extraLogging,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -878,7 +878,7 @@ export default class EppoClient {
     });
 
     return {
-      createdAt: '',
+      createdAt: new Date().toISOString(),
       environment: configDetails.configEnvironment,
       flags,
       format: FormatEnum.PRECOMPUTED,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -23,12 +23,9 @@ import { Evaluator, FlagEvaluation, noneResult } from '../evaluator';
 import { BoundedEventQueue } from '../events/bounded-event-queue';
 import EventDispatcher from '../events/event-dispatcher';
 import NoOpEventDispatcher from '../events/no-op-event-dispatcher';
-import {
-  FlagEvaluationDetailsBuilder,
-  IFlagEvaluationDetails,
-} from '../flag-evaluation-details-builder';
+import { FlagEvaluationDetailsBuilder, IFlagEvaluationDetails } from '../flag-evaluation-details-builder';
 import { FlagEvaluationError } from '../flag-evaluation-error';
-import FetchHttpClient from '../http-client';
+import FetchHttpClient, { IPrecomputedFlagsResponse } from '../http-client';
 import {
   BanditParameters,
   BanditVariation,
@@ -882,11 +879,18 @@ export default class EppoClient {
     return flags;
   }
 
-  exportPrecomputedAssignments(
+  /**
+   * Computes and returns assignments for a subject from all loaded flags.
+   *
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
+   * @param subjectAttributes optional attributes associated with the subject, for example name and email.   * The
+   * @param obfuscated optional whether to obfuscate the results.
+   */
+  getPrecomputedAssignments(
     subjectKey: string,
     subjectAttributes: Attributes = {},
     obfuscated = false,
-  ): string {
+  ): IPrecomputedFlagsResponse {
     const configDetails = this.getConfigDetails();
     let flags = this.getAllAssignments(subjectKey, subjectAttributes);
 
@@ -894,13 +898,12 @@ export default class EppoClient {
       flags = obfuscatePrecomputedFlags(flags);
     }
 
-    const response = {
+    return {
       createdAt: new Date().toISOString(),
       environment: configDetails.configEnvironment,
       flags,
-      format: obfuscated ? FormatEnum.CLIENT : FormatEnum.PRECOMPUTED,
+      format: obfuscated ? FormatEnum.PRECOMPUTED_CLIENT : FormatEnum.PRECOMPUTED,
     };
-    return JSON.stringify(response, null, 2);
   }
 
   /**

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -10,7 +10,7 @@ import { LRUInMemoryAssignmentCache } from '../cache/lru-in-memory-assignment-ca
 import { NonExpiringInMemoryAssignmentCache } from '../cache/non-expiring-in-memory-cache-assignment';
 import { TLRUInMemoryAssignmentCache } from '../cache/tlru-in-memory-assignment-cache';
 import {
-  ConfigurationWire,
+  IConfigurationWire,
   ConfigurationWireV1,
   IPrecomputedConfiguration,
   ObfuscatedPrecomputedConfiguration,
@@ -941,7 +941,7 @@ export default class EppoClient {
     subjectKey: string,
     subjectAttributes: Attributes = {},
     obfuscated = false,
-  ): ConfigurationWire {
+  ): string {
     const configDetails = this.getConfigDetails();
     const flags = this.getAllAssignments(subjectKey, subjectAttributes);
 
@@ -959,7 +959,8 @@ export default class EppoClient {
           configDetails.configEnvironment,
         );
 
-    return new ConfigurationWireV1(precomputedConfig);
+    const configWire: IConfigurationWire = new ConfigurationWireV1(precomputedConfig);
+    return JSON.stringify(configWire);
   }
 
   /**

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -23,13 +23,17 @@ import { Evaluator, FlagEvaluation, noneResult } from '../evaluator';
 import { BoundedEventQueue } from '../events/bounded-event-queue';
 import EventDispatcher from '../events/event-dispatcher';
 import NoOpEventDispatcher from '../events/no-op-event-dispatcher';
-import { FlagEvaluationDetailsBuilder, IFlagEvaluationDetails } from '../flag-evaluation-details-builder';
+import {
+  FlagEvaluationDetailsBuilder,
+  IFlagEvaluationDetails,
+} from '../flag-evaluation-details-builder';
 import { FlagEvaluationError } from '../flag-evaluation-error';
-import FetchHttpClient, { IPrecomputedFlagsResponse } from '../http-client';
+import FetchHttpClient from '../http-client';
 import {
   BanditParameters,
   BanditVariation,
   ConfigDetails,
+  ConfigurationWireFormat,
   Flag,
   FormatEnum,
   ObfuscatedFlag,
@@ -859,7 +863,7 @@ export default class EppoClient {
         this.isObfuscated,
       );
 
-      // allocationKey is set along with variation when there is a result. this if check appeases typescript below
+      // allocationKey is set along with variation when there is a result. this check appeases typescript below
       if (!evaluation.variation || !evaluation.allocationKey) {
         logger.info(`[Eppo SDK] No assigned variation: ${flagKey}`);
         return;
@@ -890,7 +894,7 @@ export default class EppoClient {
     subjectKey: string,
     subjectAttributes: Attributes = {},
     obfuscated = false,
-  ): IPrecomputedFlagsResponse {
+  ): ConfigurationWireFormat {
     const configDetails = this.getConfigDetails();
     let flags = this.getAllAssignments(subjectKey, subjectAttributes);
 
@@ -899,10 +903,15 @@ export default class EppoClient {
     }
 
     return {
-      createdAt: new Date().toISOString(),
-      environment: configDetails.configEnvironment,
-      flags,
-      format: obfuscated ? FormatEnum.PRECOMPUTED_CLIENT : FormatEnum.PRECOMPUTED,
+      precomputed: {
+        obfuscated,
+        subjectKey,
+        subjectAttributes,
+        createdAt: new Date().toISOString(),
+        environment: configDetails.configEnvironment,
+        flags,
+        format: FormatEnum.PRECOMPUTED,
+      },
     };
   }
 

--- a/src/client/eppo-precomputed-client.spec.ts
+++ b/src/client/eppo-precomputed-client.spec.ts
@@ -92,6 +92,7 @@ describe('EppoPrecomputedClient E2E test', () => {
 
   const precomputedFlagKey = 'mock-flag';
   const mockPrecomputedFlag: PrecomputedFlag = {
+    flagKey: precomputedFlagKey,
     variationKey: 'a',
     variationValue: 'variation-a',
     allocationKey: 'allocation-a',

--- a/src/client/eppo-precomputed-client.spec.ts
+++ b/src/client/eppo-precomputed-client.spec.ts
@@ -737,6 +737,7 @@ describe('EppoPrecomputedClient E2E test', () => {
 
       await store.setEntries({
         'test-flag': {
+          flagKey: precomputedFlagKey,
           variationType: VariationType.STRING,
           variationKey: 'control',
           variationValue: 'test-value',

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,89 @@
+import { Environment, FormatEnum, PrecomputedFlag } from './interfaces';
+import { obfuscatePrecomputedFlags } from './obfuscation';
+import { Attributes, ContextAttributes } from './types';
+
+export interface IPrecomputedConfiguration {
+  readonly createdAt: string;
+
+  readonly subjectKey: string;
+
+  // Optional in case server does not want to expose attributes to a client.
+  readonly subjectAttributes?: Attributes | ContextAttributes;
+
+  readonly obfuscated: boolean;
+
+  /// `format` is always `AssignmentFormat::Precomputed`.
+  readonly format: FormatEnum;
+
+  /// Salt used for hashing md5-encoded strings.
+  readonly salt: string; // base64 encoded
+
+  // Environment might be missing if configuration was absent during evaluation.
+  readonly environment?: Environment;
+  readonly flags: Record<string, PrecomputedFlag>; // md5 hashed flag key
+}
+
+export class PrecomputedConfiguration implements IPrecomputedConfiguration {
+  readonly salt = '';
+  readonly obfuscated = false;
+  readonly createdAt: string;
+  readonly format = FormatEnum.PRECOMPUTED;
+
+  constructor(
+    readonly subjectKey: string,
+    readonly flags: Record<string, PrecomputedFlag>,
+    readonly subjectAttributes?: Attributes | ContextAttributes,
+    readonly environment?: Environment,
+  ) {
+    this.createdAt = new Date().toISOString();
+  }
+}
+
+export class ObfuscatedPrecomputedConfiguration implements IPrecomputedConfiguration {
+  readonly salt: string;
+  readonly obfuscated = true;
+  readonly createdAt: string;
+  readonly format = FormatEnum.PRECOMPUTED;
+  readonly flags: Record<string, PrecomputedFlag>;
+
+  constructor(
+    readonly subjectKey: string,
+    flags: Record<string, PrecomputedFlag>,
+    readonly subjectAttributes?: Attributes | ContextAttributes,
+    readonly environment?: Environment,
+  ) {
+    this.salt = '';
+    this.flags = obfuscatePrecomputedFlags(flags);
+
+    this.createdAt = new Date().toISOString();
+  }
+}
+
+// export class ObfuscatedPrecomputedResponse implements PrecomputedResponse {
+//   createdAt: string;
+//   environment: Environment;
+//   flags: Record<string, PrecomputedFlag>;
+//   format: FormatEnum;
+//   obfuscated: boolean;
+//   subjectKey: string;
+//
+// }
+
+// "Wire" in the name means "in-transit"/"file" format.
+// In-memory representation may differ significantly and is up to SDKs.
+export interface ConfigurationWire {
+  /**
+   * Version field should be incremented for breaking format changes.
+   * For example, removing required fields or changing field type/meaning.
+   */
+  readonly version: number;
+
+  // TODO: Add flags and bandits for offline/non-precomputed initialization
+  readonly precomputed?: IPrecomputedConfiguration;
+}
+
+export class ConfigurationWireV1 implements ConfigurationWire {
+  constructor(readonly precomputed?: IPrecomputedConfiguration) {}
+
+  version = 1;
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,5 +1,5 @@
 import { Environment, FormatEnum, PrecomputedFlag } from './interfaces';
-import { obfuscatePrecomputedFlags } from './obfuscation';
+import { generateSalt, obfuscatePrecomputedFlags, Salt } from './obfuscation';
 import { Attributes, ContextAttributes } from './types';
 
 export interface IPrecomputedConfiguration {
@@ -45,6 +45,7 @@ export class ObfuscatedPrecomputedConfiguration implements IPrecomputedConfigura
   readonly createdAt: string;
   readonly format = FormatEnum.PRECOMPUTED;
   readonly flags: Record<string, PrecomputedFlag>;
+  private saltBase: Salt;
 
   constructor(
     readonly subjectKey: string,
@@ -52,8 +53,9 @@ export class ObfuscatedPrecomputedConfiguration implements IPrecomputedConfigura
     readonly subjectAttributes?: Attributes | ContextAttributes,
     readonly environment?: Environment,
   ) {
-    this.salt = '';
-    this.flags = obfuscatePrecomputedFlags(flags);
+    this.saltBase = generateSalt();
+    this.salt = this.saltBase.base64String;
+    this.flags = obfuscatePrecomputedFlags(this.saltBase.saltString, flags);
 
     this.createdAt = new Date().toISOString();
   }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -12,15 +12,15 @@ export interface IPrecomputedConfiguration {
 
   readonly obfuscated: boolean;
 
-  /// `format` is always `AssignmentFormat::Precomputed`.
+  // `format` is always `PRECOMPUTED`
   readonly format: FormatEnum;
 
-  /// Salt used for hashing md5-encoded strings.
-  readonly salt: string; // base64 encoded
+  // Salt used for hashing md5-encoded strings.
+  readonly salt: string;
 
   // Environment might be missing if configuration was absent during evaluation.
   readonly environment?: Environment;
-  readonly flags: Record<string, PrecomputedFlag>; // md5 hashed flag key
+  readonly flags: Record<string, PrecomputedFlag>;
 }
 
 export class PrecomputedConfiguration implements IPrecomputedConfiguration {
@@ -60,16 +60,6 @@ export class ObfuscatedPrecomputedConfiguration implements IPrecomputedConfigura
     this.createdAt = new Date().toISOString();
   }
 }
-
-// export class ObfuscatedPrecomputedResponse implements PrecomputedResponse {
-//   createdAt: string;
-//   environment: Environment;
-//   flags: Record<string, PrecomputedFlag>;
-//   format: FormatEnum;
-//   obfuscated: boolean;
-//   subjectKey: string;
-//
-// }
 
 // "Wire" in the name means "in-transit"/"file" format.
 // In-memory representation may differ significantly and is up to SDKs.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,7 +2,7 @@ import { Environment, FormatEnum, PrecomputedFlag } from './interfaces';
 import { generateSalt, obfuscatePrecomputedFlags, Salt } from './obfuscation';
 import { Attributes, ContextAttributes } from './types';
 
-export interface PrecomputedConfigurationResponse {
+export interface IPrecomputedConfigurationResponse {
   // `format` is always `PRECOMPUTED`
   readonly format: FormatEnum;
   readonly obfuscated: boolean;
@@ -32,7 +32,7 @@ export class PrecomputedConfiguration implements IPrecomputedConfiguration {
     readonly subjectAttributes?: Attributes | ContextAttributes,
     environment?: Environment,
   ) {
-    const precomputedResponse: PrecomputedConfigurationResponse = {
+    const precomputedResponse: IPrecomputedConfigurationResponse = {
       format: FormatEnum.PRECOMPUTED,
       obfuscated: false,
       salt: '',
@@ -57,7 +57,7 @@ export class ObfuscatedPrecomputedConfiguration implements IPrecomputedConfigura
   ) {
     this.saltBase = generateSalt();
 
-    const precomputedResponse: PrecomputedConfigurationResponse = {
+    const precomputedResponse: IPrecomputedConfigurationResponse = {
       format: FormatEnum.PRECOMPUTED,
       obfuscated: true,
       salt: this.saltBase.base64String,
@@ -71,7 +71,7 @@ export class ObfuscatedPrecomputedConfiguration implements IPrecomputedConfigura
 
 // "Wire" in the name means "in-transit"/"file" format.
 // In-memory representation may differ significantly and is up to SDKs.
-export interface ConfigurationWire {
+export interface IConfigurationWire {
   /**
    * Version field should be incremented for breaking format changes.
    * For example, removing required fields or changing field type/meaning.
@@ -82,8 +82,7 @@ export interface ConfigurationWire {
   readonly precomputed?: IPrecomputedConfiguration;
 }
 
-export class ConfigurationWireV1 implements ConfigurationWire {
-  constructor(readonly precomputed?: IPrecomputedConfiguration) {}
-
+export class ConfigurationWireV1 implements IConfigurationWire {
   version = 1;
+  constructor(readonly precomputed?: IPrecomputedConfiguration) {}
 }

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -1,5 +1,5 @@
 import ApiEndpoints from './api-endpoints';
-import { PrecomputedConfigurationResponse } from './configuration';
+import { IPrecomputedConfigurationResponse } from './configuration';
 import {
   BanditParameters,
   BanditVariation,
@@ -47,7 +47,7 @@ export interface IHttpClient {
   getBanditParameters(): Promise<IBanditParametersResponse | undefined>;
   getPrecomputedFlags(
     payload: PrecomputedFlagsPayload,
-  ): Promise<PrecomputedConfigurationResponse | undefined>;
+  ): Promise<IPrecomputedConfigurationResponse | undefined>;
   rawGet<T>(url: URL): Promise<T | undefined>;
   rawPost<T, P>(url: URL, payload: P): Promise<T | undefined>;
 }
@@ -67,9 +67,9 @@ export default class FetchHttpClient implements IHttpClient {
 
   async getPrecomputedFlags(
     payload: PrecomputedFlagsPayload,
-  ): Promise<PrecomputedConfigurationResponse | undefined> {
+  ): Promise<IPrecomputedConfigurationResponse | undefined> {
     const url = this.apiEndpoints.precomputedFlagsEndpoint();
-    return await this.rawPost<PrecomputedConfigurationResponse, PrecomputedFlagsPayload>(
+    return await this.rawPost<IPrecomputedConfigurationResponse, PrecomputedFlagsPayload>(
       url,
       payload,
     );

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -1,11 +1,11 @@
 import ApiEndpoints from './api-endpoints';
+import { IPrecomputedConfiguration } from './configuration';
 import {
   BanditParameters,
   BanditVariation,
   Environment,
   Flag,
   FormatEnum,
-  PrecomputedFlag,
   PrecomputedFlagsPayload,
 } from './interfaces';
 import { Attributes } from './types';
@@ -42,19 +42,12 @@ export interface IBanditParametersResponse {
   bandits: Record<string, BanditParameters>;
 }
 
-export interface IPrecomputedFlagsResponse {
-  createdAt: string;
-  format: FormatEnum;
-  environment: Environment;
-  flags: Record<string, PrecomputedFlag>;
-}
-
 export interface IHttpClient {
   getUniversalFlagConfiguration(): Promise<IUniversalFlagConfigResponse | undefined>;
   getBanditParameters(): Promise<IBanditParametersResponse | undefined>;
   getPrecomputedFlags(
     payload: PrecomputedFlagsPayload,
-  ): Promise<IPrecomputedFlagsResponse | undefined>;
+  ): Promise<IPrecomputedConfiguration | undefined>;
   rawGet<T>(url: URL): Promise<T | undefined>;
   rawPost<T, P>(url: URL, payload: P): Promise<T | undefined>;
 }
@@ -74,9 +67,9 @@ export default class FetchHttpClient implements IHttpClient {
 
   async getPrecomputedFlags(
     payload: PrecomputedFlagsPayload,
-  ): Promise<IPrecomputedFlagsResponse | undefined> {
+  ): Promise<IPrecomputedConfiguration | undefined> {
     const url = this.apiEndpoints.precomputedFlagsEndpoint();
-    return await this.rawPost<IPrecomputedFlagsResponse, PrecomputedFlagsPayload>(url, payload);
+    return await this.rawPost<IPrecomputedConfiguration, PrecomputedFlagsPayload>(url, payload);
   }
 
   async rawGet<T>(url: URL): Promise<T | undefined> {

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -1,5 +1,5 @@
 import ApiEndpoints from './api-endpoints';
-import { IPrecomputedConfiguration } from './configuration';
+import { PrecomputedConfigurationResponse } from './configuration';
 import {
   BanditParameters,
   BanditVariation,
@@ -47,7 +47,7 @@ export interface IHttpClient {
   getBanditParameters(): Promise<IBanditParametersResponse | undefined>;
   getPrecomputedFlags(
     payload: PrecomputedFlagsPayload,
-  ): Promise<IPrecomputedConfiguration | undefined>;
+  ): Promise<PrecomputedConfigurationResponse | undefined>;
   rawGet<T>(url: URL): Promise<T | undefined>;
   rawPost<T, P>(url: URL, payload: P): Promise<T | undefined>;
 }
@@ -67,9 +67,12 @@ export default class FetchHttpClient implements IHttpClient {
 
   async getPrecomputedFlags(
     payload: PrecomputedFlagsPayload,
-  ): Promise<IPrecomputedConfiguration | undefined> {
+  ): Promise<PrecomputedConfigurationResponse | undefined> {
     const url = this.apiEndpoints.precomputedFlagsEndpoint();
-    return await this.rawPost<IPrecomputedConfiguration, PrecomputedFlagsPayload>(url, payload);
+    return await this.rawPost<PrecomputedConfigurationResponse, PrecomputedFlagsPayload>(
+      url,
+      payload,
+    );
   }
 
   async rawGet<T>(url: URL): Promise<T | undefined> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import EppoClient, {
 import EppoPrecomputedClient, {
   PrecomputedFlagsRequestParameters,
 } from './client/eppo-precomputed-client';
-import { ConfigurationWire } from './configuration';
+import { IConfigurationWire, IPrecomputedConfigurationResponse } from './configuration';
 import FlagConfigRequestor from './configuration-requestor';
 import {
   IConfigurationStore,
@@ -65,13 +65,15 @@ export {
   IBanditLogger,
   IBanditEvent,
   IContainerExperiment,
-  PrecomputedFlagsRequestParameters,
   EppoClient,
   constants,
   ApiEndpoints,
   FlagConfigRequestor,
   HttpClient,
   validation,
+
+  // Precomputed Client
+  PrecomputedFlagsRequestParameters,
   EppoPrecomputedClient,
 
   // Configuration store
@@ -97,7 +99,6 @@ export {
   FlagConfigurationRequestParameters,
   Flag,
   ObfuscatedFlag,
-  PrecomputedFlag,
   VariationType,
   AttributeType,
   Attributes,
@@ -119,5 +120,9 @@ export {
   setSaltOverrideForTests,
 
   // Configuration interchange.
-  ConfigurationWire,
+  IConfigurationWire,
+  IPrecomputedConfigurationResponse,
+  PrecomputedFlag,
+
+
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import EppoClient, {
 import EppoPrecomputedClient, {
   PrecomputedFlagsRequestParameters,
 } from './client/eppo-precomputed-client';
+import { ConfigurationWire } from './configuration';
 import FlagConfigRequestor from './configuration-requestor';
 import {
   IConfigurationStore,
@@ -44,6 +45,7 @@ import NamedEventQueue from './events/named-event-queue';
 import NetworkStatusListener from './events/network-status-listener';
 import HttpClient from './http-client';
 import { PrecomputedFlag, Flag, ObfuscatedFlag, VariationType } from './interfaces';
+import { setSaltOverrideForTests } from './obfuscation';
 import {
   AttributeType,
   Attributes,
@@ -114,4 +116,8 @@ export {
   NetworkStatusListener,
   DefaultEventDispatcher,
   Event,
+  setSaltOverrideForTests,
+
+  // Configuration interchange.
+  ConfigurationWire,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,6 @@ import NamedEventQueue from './events/named-event-queue';
 import NetworkStatusListener from './events/network-status-listener';
 import HttpClient from './http-client';
 import { PrecomputedFlag, Flag, ObfuscatedFlag, VariationType } from './interfaces';
-import { setSaltOverrideForTests } from './obfuscation';
 import {
   AttributeType,
   Attributes,
@@ -117,7 +116,6 @@ export {
   NetworkStatusListener,
   DefaultEventDispatcher,
   Event,
-  setSaltOverrideForTests,
 
   // Configuration interchange.
   IConfigurationWire,

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,4 @@ export {
   IConfigurationWire,
   IPrecomputedConfigurationResponse,
   PrecomputedFlag,
-
-
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -42,6 +42,7 @@ export interface Allocation {
 export interface Environment {
   name: string;
 }
+export const UNKNOWN_ENVIRONMENT_NAME = 'UNKNOWN';
 
 export interface ConfigDetails {
   configFetchedAt: string;
@@ -143,6 +144,7 @@ export enum FormatEnum {
 }
 
 export interface PrecomputedFlag {
+  flagKey: string;
   allocationKey: string;
   variationKey: string;
   variationType: VariationType;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,6 @@
+import { IPrecomputedFlagsResponse } from './http-client';
 import { Rule } from './rules';
-import { Attributes } from './types';
+import { Attributes, ContextAttributes } from './types';
 
 export enum VariationType {
   STRING = 'STRING',
@@ -140,7 +141,6 @@ export enum FormatEnum {
   SERVER = 'SERVER',
   CLIENT = 'CLIENT',
   PRECOMPUTED = 'PRECOMPUTED',
-  PRECOMPUTED_CLIENT = 'PRECOMPUTED_CLIENT',
 }
 
 export interface PrecomputedFlag {
@@ -150,6 +150,16 @@ export interface PrecomputedFlag {
   variationValue: string;
   extraLogging: Record<string, string>;
   doLog: boolean;
+}
+
+export interface PrecomputedResponse extends IPrecomputedFlagsResponse {
+  obfuscated: boolean;
+  subjectKey: string;
+  subjectAttributes: Attributes | ContextAttributes;
+}
+
+export interface ConfigurationWireFormat {
+  precomputed?: PrecomputedResponse;
 }
 
 export interface PrecomputedFlagsDetails {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -140,6 +140,7 @@ export enum FormatEnum {
   SERVER = 'SERVER',
   CLIENT = 'CLIENT',
   PRECOMPUTED = 'PRECOMPUTED',
+  PRECOMPUTED_CLIENT = 'PRECOMPUTED_CLIENT',
 }
 
 export interface PrecomputedFlag {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,5 @@
-import { IPrecomputedFlagsResponse } from './http-client';
 import { Rule } from './rules';
-import { Attributes, ContextAttributes } from './types';
+import { Attributes } from './types';
 
 export enum VariationType {
   STRING = 'STRING',
@@ -150,16 +149,6 @@ export interface PrecomputedFlag {
   variationValue: string;
   extraLogging: Record<string, string>;
   doLog: boolean;
-}
-
-export interface PrecomputedResponse extends IPrecomputedFlagsResponse {
-  obfuscated: boolean;
-  subjectKey: string;
-  subjectAttributes: Attributes | ContextAttributes;
-}
-
-export interface ConfigurationWireFormat {
-  precomputed?: PrecomputedResponse;
 }
 
 export interface PrecomputedFlagsDetails {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -144,7 +144,7 @@ export enum FormatEnum {
 }
 
 export interface PrecomputedFlag {
-  flagKey: string;
+  flagKey?: string;
   allocationKey: string;
   variationKey: string;
   variationType: VariationType;

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -1,6 +1,8 @@
 import base64 = require('js-base64');
 import * as SparkMD5 from 'spark-md5';
 
+import { PrecomputedFlag } from './interfaces';
+
 export function getMD5Hash(input: string): string {
   return SparkMD5.hash(input);
 }
@@ -11,4 +13,21 @@ export function encodeBase64(input: string) {
 
 export function decodeBase64(input: string) {
   return base64.atobPolyfill(input);
+}
+
+export function obfuscatePrecomputedFlags(
+  precomputedFlags: Record<string, PrecomputedFlag>,
+): Record<string, PrecomputedFlag> {
+  const response: Record<string, PrecomputedFlag> = {};
+  Object.keys(precomputedFlags).map((flagKey) => {
+    const assignment = precomputedFlags[flagKey];
+
+    response[getMD5Hash(flagKey)] = {
+      ...assignment,
+      allocationKey: getMD5Hash(assignment.allocationKey),
+      variationKey: getMD5Hash(assignment.variationKey),
+      variationValue: encodeBase64(assignment.variationValue),
+    };
+  });
+  return response;
 }

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -23,7 +23,9 @@ export function obfuscatePrecomputedFlags(
     const assignment = precomputedFlags[flagKey];
 
     response[getMD5Hash(flagKey)] = {
-      ...assignment,
+      variationType: assignment.variationType,
+      extraLogging: assignment.extraLogging,
+      doLog: assignment.doLog,
       allocationKey: getMD5Hash(assignment.allocationKey),
       variationKey: getMD5Hash(assignment.variationKey),
       variationValue: encodeBase64(assignment.variationValue),

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -8,7 +8,7 @@ export function getMD5Hash(input: string): string {
 }
 
 function saltedHasher(salt: string) {
-  return (input: string) => SparkMD5.hash(salt + input);
+  return (input: string) => getMD5Hash(salt + input);
 }
 
 export function encodeBase64(input: string) {
@@ -34,7 +34,9 @@ export function obfuscatePrecomputedFlags(
       Object.entries(assignment.extraLogging).map((kvArr) => kvArr.map(encodeBase64)),
     );
 
-    response[hash(flagKey)] = {
+    const hashedKey = hash(flagKey);
+    response[hashedKey] = {
+      flagKey: hashedKey,
       variationType: assignment.variationType,
       extraLogging: encodedExtraLogging,
       doLog: assignment.doLog,

--- a/src/precomputed-requestor.ts
+++ b/src/precomputed-requestor.ts
@@ -1,7 +1,7 @@
 import { IConfigurationStore } from './configuration-store/configuration-store';
 import { hydrateConfigurationStore } from './configuration-store/configuration-store-utils';
 import { IHttpClient } from './http-client';
-import { PrecomputedFlag } from './interfaces';
+import { PrecomputedFlag, UNKNOWN_ENVIRONMENT_NAME } from './interfaces';
 import { Attributes } from './types';
 
 // Requests AND stores precomputed flags, reuses the configuration store
@@ -25,7 +25,7 @@ export default class PrecomputedFlagRequestor {
 
     await hydrateConfigurationStore(this.precomputedFlagStore, {
       entries: precomputedResponse.flags,
-      environment: precomputedResponse.environment ?? { name: '' }, // NOTE: not sure wha the right default to have is here...
+      environment: precomputedResponse.environment ?? { name: UNKNOWN_ENVIRONMENT_NAME },
       createdAt: precomputedResponse.createdAt,
       format: precomputedResponse.format,
     });

--- a/src/precomputed-requestor.ts
+++ b/src/precomputed-requestor.ts
@@ -25,7 +25,7 @@ export default class PrecomputedFlagRequestor {
 
     await hydrateConfigurationStore(this.precomputedFlagStore, {
       entries: precomputedResponse.flags,
-      environment: precomputedResponse.environment,
+      environment: precomputedResponse.environment ?? { name: '' }, // NOTE: not sure wha the right default to have is here...
       createdAt: precomputedResponse.createdAt,
       format: precomputedResponse.format,
     });


### PR DESCRIPTION
---
labels: mergeable
---
Towards: FF-3657

## Motivation and Context
We need the node-server to produce a set of precomputed flags which can be ingested by an `EppoPrecomputedClient`. This format is already established by the current edge-compute function and leveraged by this implementation

## Description
New method
```ts
EppoClient {
  getPrecomputedAssignments(subject, subjectAttributes, obfuscated = false): IPrecomputedFlagsResponse
}
```


## How has this been tested?
- new unit tests
