### PR TITLE
feat: getBestBanditAction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.5.4",
+  "version": "4.6.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -428,7 +428,6 @@ describe('BanditEvaluator', () => {
 
   describe('evaluateBestBandit', () => {
     it('evaluates the bandit with action contexts', () => {
-      const flagKey = 'test_flag';
       const subjectAttributes: ContextAttributes = {
         numericAttributes: { age: 25 },
         categoricalAttributes: { location: 'US' },

--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -498,38 +498,22 @@ describe('BanditEvaluator', () => {
       };
 
       // Subject A gets assigned action 2
-      const resultA = banditEvaluator.evaluateBestBandit(
-        flagKey,
-        'subjectA',
+      const resultA = banditEvaluator.evaluateBestBanditAction(
         subjectAttributes,
         actions,
         banditModel,
       );
 
-      expect(resultA.subjectAttributes).toStrictEqual(subjectAttributes);
-      expect(resultA.actionKey).toBe('action2');
-      expect(resultA.actionAttributes).toStrictEqual(actions.action2);
-      expect(resultA.actionScore).toBe(4.3);
-      expect(resultA.actionWeight).toBeCloseTo(0.5074);
-      expect(resultA.gamma).toBe(banditModel.gamma);
-      expect(resultA.optimalityGap).toBe(0);
+      expect(resultA).toEqual('action2');
 
       // Subject B gets assigned action 1 because of the missing location penalty
-      const resultB = banditEvaluator.evaluateBestBandit(
-        flagKey,
-        'subjectB',
+      const resultB = banditEvaluator.evaluateBestBanditAction(
         subjectAttributesB,
         actions,
         banditModel,
       );
 
-      expect(resultB.subjectAttributes).toStrictEqual(subjectAttributesB);
-      expect(resultB.actionKey).toBe('action1');
-      expect(resultB.actionAttributes).toStrictEqual(actions.action1);
-      expect(resultB.actionScore).toBe(3.8);
-      expect(resultB.actionWeight).toBeCloseTo(0.5594);
-      expect(resultB.gamma).toBe(banditModel.gamma);
-      expect(resultB.optimalityGap).toBe(0);
+      expect(resultB).toEqual('action1');
     });
   });
 });

--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -498,7 +498,13 @@ describe('BanditEvaluator', () => {
       };
 
       // Subject A gets assigned action 2
-      const resultA = banditEvaluator.evaluateBestBandit(flagKey, 'subjectA', subjectAttributes, actions, banditModel);
+      const resultA = banditEvaluator.evaluateBestBandit(
+        flagKey,
+        'subjectA',
+        subjectAttributes,
+        actions,
+        banditModel,
+      );
 
       expect(resultA.subjectAttributes).toStrictEqual(subjectAttributes);
       expect(resultA.actionKey).toBe('action2');
@@ -509,7 +515,13 @@ describe('BanditEvaluator', () => {
       expect(resultA.optimalityGap).toBe(0);
 
       // Subject B gets assigned action 1 because of the missing location penalty
-      const resultB = banditEvaluator.evaluateBestBandit(flagKey, 'subjectB', subjectAttributesB, actions, banditModel);
+      const resultB = banditEvaluator.evaluateBestBandit(
+        flagKey,
+        'subjectB',
+        subjectAttributesB,
+        actions,
+        banditModel,
+      );
 
       expect(resultB.subjectAttributes).toStrictEqual(subjectAttributesB);
       expect(resultB.actionKey).toBe('action1');

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -236,7 +236,7 @@ export class BanditEvaluator {
     topAction: string | null;
   } {
     const actionScoreEntries = Object.entries(actionScores);
-    // First find the action with the highest score
+    // Find the action with the highest score, tie-breaking by name, selecting the alpha-numerically smaller key.
     let topScore: number | null = null;
     let topAction: string | null = null;
     actionScoreEntries.forEach(([actionKey, actionScore]) => {

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -477,7 +477,7 @@ describe('EppoClient Bandits E2E test', () => {
           area_code: '303', // categorical area code
         };
 
-        const banditAssignment = client.getBestBanditAction(
+        const banditAssignment = client.getBestAction(
           flagKey,
           subjectAttributesWithAreaCode,
           actions,

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -477,15 +477,13 @@ describe('EppoClient Bandits E2E test', () => {
           area_code: '303', // categorical area code
         };
 
-        const banditAssignment = client.getBanditAction(
+        const banditAssignment = client.getBestBanditAction(
           flagKey,
-          'henry',
           subjectAttributesWithAreaCode,
           actions,
           'default',
         );
-        expect(banditAssignment.action).toBe('adidas');
-        expect(banditAssignment.variation).toBe('banner_bandit');
+        expect(banditAssignment).toBe('adidas');
       });
     });
 

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -452,6 +452,43 @@ describe('EppoClient Bandits E2E test', () => {
       });
     });
 
+    describe('Best bandit action', () => {
+      it('Selects the highest scoring action', async () => {
+        const actions: Record<string, ContextAttributes> = {
+          nike: {
+            numericAttributes: { brand_affinity: 1.0 },
+            categoricalAttributes: {},
+          },
+          adidas: {
+            numericAttributes: { brand_affinity: 1.0 },
+            categoricalAttributes: {},
+          },
+          reebok: {
+            numericAttributes: { brand_affinity: 2.0 },
+            categoricalAttributes: {},
+          },
+        };
+
+        const subjectAttributesWithAreaCode: Attributes = {
+          age: 25,
+          mistake: 'oops',
+          country: 'USA',
+          gender_identity: 'female',
+          area_code: '303', // categorical area code
+        };
+
+        const banditAssignment = client.getBanditAction(
+          flagKey,
+          'henry',
+          subjectAttributesWithAreaCode,
+          actions,
+          'default',
+        );
+        expect(banditAssignment.action).toBe('adidas');
+        expect(banditAssignment.variation).toBe('banner_bandit');
+      });
+    });
+
     describe('Assignment logging deduplication', () => {
       let mockEvaluateFlag: jest.SpyInstance;
       let mockEvaluateBandit: jest.SpyInstance;

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -502,22 +502,18 @@ export default class EppoClient {
   }
 
   /**
-   * Evaluates the supplied actions and returns the best ranked action.
+   * Evaluates the supplied actions using the first bandit associated with `flagKey` and returns the best ranked action.
    *
    * This method should be considered **preview** and is subject to change as requirements mature.
    *
-   * CAUTION: This method does not do any logging or assignment computation and so calling this method will have
+   * NOTE: This method does not do any logging or assignment computation and so calling this method will have
    * NO IMPACT on bandit and experiment training.
    *
    * Only use this method under certain circumstances (i.e. where the impact of the choice of bandit cannot be measured,
    * but you want to put the "best foot forward", for example, when being web-crawled).
    *
-   * @param flagKey
-   * @param subjectAttributes
-   * @param actions
-   * @param defaultAction
    */
-  getBestBanditAction(
+  getBestAction(
     flagKey: string,
     subjectAttributes: BanditSubjectAttributes,
     actions: BanditActions,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -513,14 +513,12 @@ export default class EppoClient {
    * but you want to put the "best foot forward", for example, when being web-crawled).
    *
    * @param flagKey
-   * @param subjectKey
    * @param subjectAttributes
    * @param actions
    * @param defaultAction
    */
   getBestBanditAction(
     flagKey: string,
-    subjectKey: string,
     subjectAttributes: BanditSubjectAttributes,
     actions: BanditActions,
     defaultAction: string,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -523,7 +523,7 @@ export default class EppoClient {
     actions: BanditActions,
     defaultAction: string,
   ): string {
-    let selectedAction = defaultAction;
+    let result: string | null = null;
 
     const flagBanditVariations = this.banditVariationConfigurationStore?.get(flagKey);
     const banditKey = flagBanditVariations?.at(0)?.key;
@@ -535,7 +535,7 @@ export default class EppoClient {
           this.ensureContextualSubjectAttributes(subjectAttributes);
         const actionsWithContextualAttributes = this.ensureActionsWithContextualAttributes(actions);
 
-        selectedAction = this.banditEvaluator.evaluateBestBanditAction(
+        result = this.banditEvaluator.evaluateBestBanditAction(
           contextualSubjectAttributes,
           actionsWithContextualAttributes,
           banditParameters.modelData,
@@ -543,7 +543,7 @@ export default class EppoClient {
       }
     }
 
-    return selectedAction;
+    return result ?? defaultAction;
   }
 
   getBanditActionDetails(

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -504,8 +504,13 @@ export default class EppoClient {
   /**
    * Evaluates the supplied actions and returns the best ranked action.
    *
-   * Variation assignment is skipped all together and the first bandit referenced by `flagKey` is used.
-   * No logging is done from this method.
+   * This method should be considered **preview** and is subject to change as requirements mature.
+   *
+   * CAUTION: This method does not do any logging or assignment computation and so calling this method will have
+   * NO IMPACT on bandit and experiment training.
+   *
+   * Only use this method under certain circumstances (i.e. where the impact of the choice of bandit cannot be measured,
+   * but you want to put the "best foot forward", for example, when being web-crawled).
    *
    * @param flagKey
    * @param subjectKey


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: FF-3669

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)
Coinbase would like the ability to get the best action (rather than a probabilistic selection) for situations like when they are indexed by Google Crawlers.


## Description
[//]: # (Describe your changes in detail)
- `BanditEvaluator.evaluateBestBanditAction`, new method to score and weigh the bandits, then select the highest scoring action
- `EppoClient.getBestBanditAction`, to provide a means to select the best action.
