### PR TITLE
chore: Ensure event payload is an object

### DIFF
--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -979,12 +979,12 @@ export default class EppoClient {
    * Enqueues an arbitrary event. Events must have a type and a payload.
    * TODO: enforce max message size
    */
-  track(type: string, event: unknown) {
+  track(type: string, payload: Record<string, unknown>) {
     this.eventDispatcher.dispatch({
       uuid: randomUUID(),
       type,
       timestamp: new Date().getTime(),
-      payload: event,
+      payload,
     });
   }
 

--- a/src/events/batch-event-processor.spec.ts
+++ b/src/events/batch-event-processor.spec.ts
@@ -11,9 +11,9 @@ describe('BatchEventProcessor', () => {
       expect(processor.nextBatch()).toHaveLength(0);
       const timestamp = new Date().getTime();
       const type = 'test';
-      const event1 = { uuid: 'foo-1', payload: 'event1', timestamp, type };
-      const event2 = { uuid: 'foo-2', payload: 'event2', timestamp, type };
-      const event3 = { uuid: 'foo-3', payload: 'event3', timestamp, type };
+      const event1 = { uuid: 'foo-1', payload: { id: 'event1' }, timestamp, type };
+      const event2 = { uuid: 'foo-2', payload: { id: 'event2' }, timestamp, type };
+      const event3 = { uuid: 'foo-3', payload: { id: 'event3' }, timestamp, type };
       processor.push(event1);
       processor.push(event2);
       processor.push(event3);

--- a/src/events/default-event-dispatcher.spec.ts
+++ b/src/events/default-event-dispatcher.spec.ts
@@ -49,19 +49,19 @@ describe('DefaultEventDispatcher', () => {
       // Add three events to the queue
       dispatcher.dispatch({
         uuid: 'foo-1',
-        payload: 'event1',
+        payload: { foo: 'event1' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });
       dispatcher.dispatch({
         uuid: 'foo-2',
-        payload: 'event2',
+        payload: { foo: 'event2' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });
       dispatcher.dispatch({
         uuid: 'foo-3',
-        payload: 'event3',
+        payload: { foo: 'event3' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });
@@ -81,19 +81,19 @@ describe('DefaultEventDispatcher', () => {
       const { dispatcher } = createDispatcher();
       dispatcher.dispatch({
         uuid: 'foo-1',
-        payload: 'event1',
+        payload: { foo: 'event1' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });
       dispatcher.dispatch({
         uuid: 'foo-2',
-        payload: 'event2',
+        payload: { foo: 'event2' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });
       dispatcher.dispatch({
         uuid: 'foo-3',
-        payload: 'event3',
+        payload: { foo: 'event3' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });
@@ -114,8 +114,8 @@ describe('DefaultEventDispatcher', () => {
       let fetchOptions = fetch.mock.calls[0][1];
       let payload = JSON.parse(fetchOptions.body);
       expect(payload).toEqual([
-        expect.objectContaining({ payload: 'event1' }),
-        expect.objectContaining({ payload: 'event2' }),
+        expect.objectContaining({ payload: { foo: 'event1' } }),
+        expect.objectContaining({ payload: { foo: 'event2' } }),
       ]);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -130,7 +130,7 @@ describe('DefaultEventDispatcher', () => {
 
       fetchOptions = fetch.mock.calls[1][1];
       payload = JSON.parse(fetchOptions.body);
-      expect(payload).toEqual([expect.objectContaining({ payload: 'event3' })]);
+      expect(payload).toEqual([expect.objectContaining({ payload: { foo: 'event3' } })]);
     });
 
     it('does not schedule delivery if the queue is empty', async () => {
@@ -156,13 +156,13 @@ describe('DefaultEventDispatcher', () => {
       const { dispatcher } = createDispatcher({ networkStatusListener });
       dispatcher.dispatch({
         uuid: '1',
-        payload: 'event1',
+        payload: { foo: 'event1' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });
       dispatcher.dispatch({
         uuid: '2',
-        payload: 'event2',
+        payload: { foo: 'event2' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });
@@ -190,13 +190,13 @@ describe('DefaultEventDispatcher', () => {
       const { dispatcher } = createDispatcher({ networkStatusListener });
       dispatcher.dispatch({
         uuid: '1',
-        payload: 'event1',
+        payload: { foo: 'event1' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });
       dispatcher.dispatch({
         uuid: '2',
-        payload: 'event2',
+        payload: { foo: 'event2' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });
@@ -229,7 +229,7 @@ describe('DefaultEventDispatcher', () => {
       const { dispatcher } = createDispatcher();
       dispatcher.dispatch({
         uuid: 'foo',
-        payload: 'event1',
+        payload: { foo: 'event1' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });
@@ -258,7 +258,7 @@ describe('DefaultEventDispatcher', () => {
       const { dispatcher } = createDispatcher({ maxRetries: 1 }, eventQueue);
       dispatcher.dispatch({
         uuid: 'foo',
-        payload: 'event1',
+        payload: { foo: 'event1' },
         timestamp: new Date().getTime(),
         type: 'foo',
       });

--- a/src/events/event-dispatcher.ts
+++ b/src/events/event-dispatcher.ts
@@ -2,7 +2,7 @@ export type Event = {
   uuid: string;
   timestamp: number;
   type: string;
-  payload: unknown;
+  payload: Record<string, unknown>;
 };
 
 export default interface EventDispatcher {


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
Follow up from discussion here https://github.com/Eppo-exp/js-sdk-common/pull/162#discussion_r1876459822

## Description
Event payload `unknown` -> `Record<string, unkown>`

## How has this been tested?
Existing tests
