### PR TITLE
fix(events): Prefix event ingestion URL with scheme if none provided

### DIFF
--- a/src/events/default-event-dispatcher.ts
+++ b/src/events/default-event-dispatcher.ts
@@ -137,7 +137,7 @@ export function newDefaultEventDispatcher(
   config: Omit<EventDispatcherConfig, 'ingestionUrl'> = DEFAULT_EVENT_DISPATCHER_CONFIG,
 ): EventDispatcher {
   const sdkKeyDecoder = new SdkKeyDecoder();
-  const ingestionUrl = sdkKeyDecoder.decodeEventIngestionHostName(sdkKey);
+  const ingestionUrl = sdkKeyDecoder.decodeEventIngestionUrl(sdkKey);
   if (!ingestionUrl) {
     logger.debug(
       'Unable to parse Event ingestion URL from SDK key, falling back to no-op event dispatcher',

--- a/src/events/sdk-key-decoder.spec.ts
+++ b/src/events/sdk-key-decoder.spec.ts
@@ -3,22 +3,22 @@ import SdkKeyDecoder from './sdk-key-decoder';
 describe('SdkKeyDecoder', () => {
   const decoder = new SdkKeyDecoder();
   it('should decode the event ingestion hostname from the SDK key', () => {
-    const hostname = decoder.decodeEventIngestionHostName(
+    const hostname = decoder.decodeEventIngestionUrl(
       'zCsQuoHJxVPp895.ZWg9MTIzNDU2LmUudGVzdGluZy5lcHBvLmNsb3Vk',
     );
-    expect(hostname).toEqual('123456.e.testing.eppo.cloud');
+    expect(hostname).toEqual('https://123456.e.testing.eppo.cloud');
   });
 
   it('should decode strings with non URL-safe characters', () => {
     // this is not a really valid ingestion URL, but it's useful for testing the decoder
     const invalidUrl = 'eh=12+3456/.e.testing.eppo.cloud';
     const encoded = Buffer.from(invalidUrl).toString('base64url');
-    const hostname = decoder.decodeEventIngestionHostName(`zCsQuoHJxVPp895.${encoded}`);
-    expect(hostname).toEqual('12 3456/.e.testing.eppo.cloud');
+    const hostname = decoder.decodeEventIngestionUrl(`zCsQuoHJxVPp895.${encoded}`);
+    expect(hostname).toEqual('https://12 3456/.e.testing.eppo.cloud');
   });
 
   it("should return null if the SDK key doesn't contain the event ingestion hostname", () => {
-    expect(decoder.decodeEventIngestionHostName('zCsQuoHJxVPp895')).toBeNull();
-    expect(decoder.decodeEventIngestionHostName('zCsQuoHJxVPp895.xxxxxx')).toBeNull();
+    expect(decoder.decodeEventIngestionUrl('zCsQuoHJxVPp895')).toBeNull();
+    expect(decoder.decodeEventIngestionUrl('zCsQuoHJxVPp895.xxxxxx')).toBeNull();
   });
 });

--- a/src/events/sdk-key-decoder.ts
+++ b/src/events/sdk-key-decoder.ts
@@ -5,12 +5,20 @@ export default class SdkKeyDecoder {
    * Decodes and returns the event ingestion hostname from the provided Eppo SDK key string.
    * If the SDK key doesn't contain the event ingestion hostname, or it's invalid, it returns null.
    */
-  decodeEventIngestionHostName(sdkKey: string): string | null {
+  decodeEventIngestionUrl(sdkKey: string): string | null {
     const encodedPayload = sdkKey.split('.')[1];
     if (!encodedPayload) return null;
 
     const decodedPayload = Base64.decode(encodedPayload);
     const params = new URLSearchParams(decodedPayload);
-    return params.get('eh');
+    const hostname = params.get('eh');
+    if (!hostname) return null;
+
+    if (!hostname.startsWith('http://') && !hostname.startsWith('https://')) {
+      // prefix hostname with https scheme if none present
+      return `https://${hostname}`;
+    } else {
+      return hostname;
+    }
   }
 }


### PR DESCRIPTION
## Motivation and Context
Make sure the event ingestion URL is valid

## Description
The browser will do this if we don't explicitly set a URL scheme
<img width="716" alt="image" src="https://github.com/user-attachments/assets/115cde67-8d2a-41a2-b902-6ffd73077588">


## How has this been tested?
Updated tests


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
