### PR TITLE
fix: keep setPrecomputedFlagsRequestParameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-precomputed-client.ts
+++ b/src/client/eppo-precomputed-client.ts
@@ -57,12 +57,18 @@ export default class EppoPrecomputedClient {
     private isObfuscated = false,
   ) {}
 
+  public setPrecomputedFlagsRequestParameters(
+    precomputedFlagsRequestParameters: PrecomputedFlagsRequestParameters,
+  ) {
+    this.precomputedFlagsRequestParameters = precomputedFlagsRequestParameters;
+  }
+
   public setSubjectAndPrecomputedFlagsRequestParameters(
     precomputedFlagsRequestParameters: PrecomputedFlagsRequestParameters,
   ) {
+    this.setPrecomputedFlagsRequestParameters(precomputedFlagsRequestParameters);
     this.subjectKey = precomputedFlagsRequestParameters.precompute.subjectKey;
     this.subjectAttributes = precomputedFlagsRequestParameters.precompute.subjectAttributes;
-    this.precomputedFlagsRequestParameters = precomputedFlagsRequestParameters;
   }
 
   public setPrecomputedFlagStore(precomputedFlagStore: IConfigurationStore<PrecomputedFlag>) {


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

It's probably not an issue, but just to be safe, it's probably better to keep this method around until there's a major version bump since it is used here https://github.com/Eppo-exp/js-client-sdk/blob/d584a9e1bed0f2da756121bd0b84044c174b9909/src/index.ts#L598

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
