### PR TITLE
chore(events): Clamp `batchSize` between [min, max]

### DIFF
--- a/src/events/batch-event-processor.spec.ts
+++ b/src/events/batch-event-processor.spec.ts
@@ -8,6 +8,7 @@ describe('BatchEventProcessor', () => {
       const eventQueue = new ArrayBackedNamedEventQueue<Event>('test-queue');
       const processor = new BatchEventProcessor(eventQueue, 2);
       // force batch size to 2 for testing
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       processor['batchSize'] = 2;
       expect(processor.isEmpty()).toBeTruthy();

--- a/src/events/batch-event-processor.spec.ts
+++ b/src/events/batch-event-processor.spec.ts
@@ -24,4 +24,23 @@ describe('BatchEventProcessor', () => {
       expect(processor.isEmpty()).toBeTruthy();
     });
   });
+
+  describe('batchSize', () => {
+    const queue = new ArrayBackedNamedEventQueue<Event>('test-queue');
+
+    it('should clamp batch size to min', () => {
+      const processor = new BatchEventProcessor(queue, 2);
+      expect(processor['batchSize']).toBe(100);
+    });
+
+    it('should clamp batch size to max', () => {
+      const processor = new BatchEventProcessor(queue, 100_000_000);
+      expect(processor['batchSize']).toBe(10_000);
+    });
+
+    it('should set batch size if within bounds', () => {
+      const processor = new BatchEventProcessor(queue, 1_000);
+      expect(processor['batchSize']).toBe(1_000);
+    });
+  });
 });

--- a/src/events/batch-event-processor.spec.ts
+++ b/src/events/batch-event-processor.spec.ts
@@ -7,6 +7,9 @@ describe('BatchEventProcessor', () => {
     it('should return a batch and remove items from the queue', () => {
       const eventQueue = new ArrayBackedNamedEventQueue<Event>('test-queue');
       const processor = new BatchEventProcessor(eventQueue, 2);
+      // force batch size to 2 for testing
+      // @ts-ignore
+      processor['batchSize'] = 2;
       expect(processor.isEmpty()).toBeTruthy();
       expect(processor.nextBatch()).toHaveLength(0);
       const timestamp = new Date().getTime();

--- a/src/events/batch-event-processor.ts
+++ b/src/events/batch-event-processor.ts
@@ -1,11 +1,16 @@
 import Event from './event';
 import NamedEventQueue from './named-event-queue';
 
+const MIN_BATCH_SIZE = 100;
+const MAX_BATCH_SIZE = 10_000;
+
 export default class BatchEventProcessor {
-  constructor(
-    private readonly eventQueue: NamedEventQueue<Event>,
-    private readonly batchSize: number,
-  ) {}
+  private readonly batchSize: number;
+
+  constructor(private readonly eventQueue: NamedEventQueue<Event>, batchSize: number) {
+    // clamp batch size between min and max
+    this.batchSize = Math.max(MIN_BATCH_SIZE, Math.min(MAX_BATCH_SIZE, batchSize));
+  }
 
   nextBatch(): Event[] {
     return this.eventQueue.splice(this.batchSize);

--- a/src/events/default-event-dispatcher.spec.ts
+++ b/src/events/default-event-dispatcher.spec.ts
@@ -33,6 +33,7 @@ const createDispatcher = (
   const config = { ...defaultConfig, ...configOverrides };
   const batchProcessor = new BatchEventProcessor(eventQueue, batchSize);
   // force batch size to 2 for testing
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   batchProcessor['batchSize'] = 2;
   const dispatcher = new DefaultEventDispatcher(

--- a/src/events/default-event-dispatcher.spec.ts
+++ b/src/events/default-event-dispatcher.spec.ts
@@ -32,6 +32,9 @@ const createDispatcher = (
   };
   const config = { ...defaultConfig, ...configOverrides };
   const batchProcessor = new BatchEventProcessor(eventQueue, batchSize);
+  // force batch size to 2 for testing
+  // @ts-ignore
+  batchProcessor['batchSize'] = 2;
   const dispatcher = new DefaultEventDispatcher(
     batchProcessor,
     configOverrides.networkStatusListener || mockNetworkStatusListener,

--- a/src/events/default-event-dispatcher.ts
+++ b/src/events/default-event-dispatcher.ts
@@ -25,9 +25,7 @@ export type EventDispatcherConfig = {
   maxRetries?: number;
 };
 
-// TODO: Have more realistic default batch size based on average event payload size once we have
-//  more concrete data.
-export const DEFAULT_EVENT_DISPATCHER_BATCH_SIZE = 100;
+export const DEFAULT_EVENT_DISPATCHER_BATCH_SIZE = 1_000;
 export const DEFAULT_EVENT_DISPATCHER_CONFIG: Omit<
   EventDispatcherConfig,
   'ingestionUrl' | 'sdkKey'


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
Make sure we enforce a sane batch size for event ingestion

## Description
batchSize will be always between 100 and 10k

## How has this been tested?
Wrote test