### PR TITLE
feat: add local override functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -1148,5 +1148,23 @@ describe('EppoClient E2E test', () => {
       const normalAssignment = client.getStringAssignment(flagKey, 'subject-10', {}, 'default');
       expect(normalAssignment).toBe(variationA.value);
     });
+
+    it('returns a mapping of flag key to variation key for all active overrides', () => {
+      overrideStore.setEntries({
+        [flagKey]: {
+          key: 'override-variation',
+          value: 'override-value',
+        },
+        'other-flag': {
+          key: 'other-variation',
+          value: 'other-value',
+        },
+      });
+
+      expect(client.getOverrideVariationKeys()).toEqual({
+        [flagKey]: 'override-variation',
+        'other-flag': 'other-variation',
+      });
+    });
   });
 });

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -958,7 +958,7 @@ describe('EppoClient E2E test', () => {
       overrideStore = new MemoryOnlyConfigurationStore<Variation>();
       client = new EppoClient({
         flagConfigurationStore: storage,
-        overridesStore: overrideStore,
+        overrideStore: overrideStore,
       });
       client.setAssignmentLogger(mockLogger);
       client.useNonExpiringInMemoryAssignmentCache();
@@ -1143,7 +1143,7 @@ describe('EppoClient E2E test', () => {
         },
       });
 
-      client.unsetOverridesStore();
+      client.unsetOverrideStore();
 
       const normalAssignment = client.getStringAssignment(flagKey, 'subject-10', {}, 'default');
       expect(normalAssignment).toBe(variationA.value);

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -1134,5 +1134,19 @@ describe('EppoClient E2E test', () => {
       // Should log the normal assignment
       expect(td.explain(mockLogger.logAssignment).callCount).toBe(1);
     });
+
+    it('reverts to normal assignment after unsetting overrides store', () => {
+      overrideStore.setEntries({
+        [flagKey]: {
+          key: 'override-variation',
+          value: 'override-value',
+        },
+      });
+
+      client.unsetOverridesStore();
+
+      const normalAssignment = client.getStringAssignment(flagKey, 'subject-10', {}, 'default');
+      expect(normalAssignment).toBe(variationA.value);
+    });
   });
 });

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -116,6 +116,7 @@ export default class EppoClient {
   private configurationRequestParameters?: FlagConfigurationRequestParameters;
   private banditModelConfigurationStore?: IConfigurationStore<BanditParameters>;
   private banditVariationConfigurationStore?: IConfigurationStore<BanditVariation[]>;
+  private overridesStore?: ISyncStore<Variation>;
   private flagConfigurationStore: IConfigurationStore<Flag | ObfuscatedFlag>;
   private assignmentLogger?: IAssignmentLogger;
   private assignmentCache?: AssignmentCache;
@@ -124,7 +125,6 @@ export default class EppoClient {
   private isObfuscated: boolean;
   private requestPoller?: IPoller;
   private readonly evaluator = new Evaluator();
-  protected overridesStore?: ISyncStore<Variation>;
 
   constructor({
     eventDispatcher = new NoOpEventDispatcher(),
@@ -132,8 +132,8 @@ export default class EppoClient {
     flagConfigurationStore,
     banditVariationConfigurationStore,
     banditModelConfigurationStore,
-    configurationRequestParameters,
     overridesStore,
+    configurationRequestParameters,
   }: {
     // Dispatcher for arbitrary, application-level events (not to be confused with Eppo specific assignment
     // or bandit events). These events are application-specific and captures by EppoClient#track API.

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -141,7 +141,7 @@ export default class EppoClient {
     flagConfigurationStore: IConfigurationStore<Flag | ObfuscatedFlag>;
     banditVariationConfigurationStore?: IConfigurationStore<BanditVariation[]>;
     banditModelConfigurationStore?: IConfigurationStore<BanditParameters>;
-    overridesStore?: IConfigurationStore<Variation>;
+    overridesStore?: ISyncStore<Variation>;
     configurationRequestParameters?: FlagConfigurationRequestParameters;
     isObfuscated?: boolean;
   }) {

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -141,17 +141,17 @@ export default class EppoClient {
     flagConfigurationStore: IConfigurationStore<Flag | ObfuscatedFlag>;
     banditVariationConfigurationStore?: IConfigurationStore<BanditVariation[]>;
     banditModelConfigurationStore?: IConfigurationStore<BanditParameters>;
+    overridesStore?: IConfigurationStore<Variation>;
     configurationRequestParameters?: FlagConfigurationRequestParameters;
     isObfuscated?: boolean;
-    overridesStore?: IConfigurationStore<Variation>;
   }) {
     this.eventDispatcher = eventDispatcher;
     this.flagConfigurationStore = flagConfigurationStore;
     this.banditVariationConfigurationStore = banditVariationConfigurationStore;
     this.banditModelConfigurationStore = banditModelConfigurationStore;
+    this.overridesStore = overridesStore;
     this.configurationRequestParameters = configurationRequestParameters;
     this.isObfuscated = isObfuscated;
-    this.overridesStore = overridesStore;
   }
 
   setConfigurationRequestParameters(

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -21,7 +21,7 @@ import {
   PrecomputedConfiguration,
 } from '../configuration';
 import ConfigurationRequestor from '../configuration-requestor';
-import { IConfigurationStore } from '../configuration-store/configuration-store';
+import { IConfigurationStore, ISyncStore } from '../configuration-store/configuration-store';
 import {
   DEFAULT_INITIAL_CONFIG_REQUEST_RETRIES,
   DEFAULT_POLL_CONFIG_REQUEST_RETRIES,
@@ -124,7 +124,7 @@ export default class EppoClient {
   private isObfuscated: boolean;
   private requestPoller?: IPoller;
   private readonly evaluator = new Evaluator();
-  protected overridesStore?: IConfigurationStore<Variation>;
+  protected overridesStore?: ISyncStore<Variation>;
 
   constructor({
     eventDispatcher = new NoOpEventDispatcher(),
@@ -205,7 +205,7 @@ export default class EppoClient {
     this.isObfuscated = isObfuscated;
   }
 
-  setOverridesStore(store: IConfigurationStore<Variation>): void {
+  setOverridesStore(store: ISyncStore<Variation>): void {
     this.overridesStore = store;
   }
 
@@ -959,7 +959,6 @@ export default class EppoClient {
     const flagEvaluationDetailsBuilder = this.newFlagEvaluationDetailsBuilder(flagKey);
     const overrideVariation = this.overridesStore?.get(flagKey);
     if (overrideVariation) {
-      const configFormat = this.overridesStore?.getFormat() ?? '';
       const flagEvaluationDetails = flagEvaluationDetailsBuilder
         .setMatch(
           0,
@@ -977,7 +976,7 @@ export default class EppoClient {
         subjectAttributes,
         flagEvaluationDetails,
         doLog: false,
-        format: configFormat,
+        format: '',
         allocationKey: 'override',
         extraLogging: {},
       };

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -957,7 +957,7 @@ export default class EppoClient {
     validateNotBlank(flagKey, 'Invalid argument: flagKey cannot be blank');
 
     // Check for override early
-    const overrideVariation = this.overridesStore?.get(flagKey);
+    const overrideVariation = this.overridesStore?.get(getMD5Hash(flagKey));
     if (overrideVariation) {
       const configFormat = this.overridesStore?.getFormat() ?? '';
       const flagEvaluationDetailsBuilder = this.newFlagEvaluationDetailsBuilder(flagKey);

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -209,6 +209,10 @@ export default class EppoClient {
     this.overridesStore = store;
   }
 
+  unsetOverridesStore(): void {
+    this.overridesStore = undefined;
+  }
+
   async fetchFlagConfigurations() {
     if (!this.configurationRequestParameters) {
       throw new Error(

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -116,7 +116,7 @@ export default class EppoClient {
   private configurationRequestParameters?: FlagConfigurationRequestParameters;
   private banditModelConfigurationStore?: IConfigurationStore<BanditParameters>;
   private banditVariationConfigurationStore?: IConfigurationStore<BanditVariation[]>;
-  private overridesStore?: ISyncStore<Variation>;
+  private overrideStore?: ISyncStore<Variation>;
   private flagConfigurationStore: IConfigurationStore<Flag | ObfuscatedFlag>;
   private assignmentLogger?: IAssignmentLogger;
   private assignmentCache?: AssignmentCache;
@@ -132,7 +132,7 @@ export default class EppoClient {
     flagConfigurationStore,
     banditVariationConfigurationStore,
     banditModelConfigurationStore,
-    overridesStore,
+    overrideStore,
     configurationRequestParameters,
   }: {
     // Dispatcher for arbitrary, application-level events (not to be confused with Eppo specific assignment
@@ -141,7 +141,7 @@ export default class EppoClient {
     flagConfigurationStore: IConfigurationStore<Flag | ObfuscatedFlag>;
     banditVariationConfigurationStore?: IConfigurationStore<BanditVariation[]>;
     banditModelConfigurationStore?: IConfigurationStore<BanditParameters>;
-    overridesStore?: ISyncStore<Variation>;
+    overrideStore?: ISyncStore<Variation>;
     configurationRequestParameters?: FlagConfigurationRequestParameters;
     isObfuscated?: boolean;
   }) {
@@ -149,7 +149,7 @@ export default class EppoClient {
     this.flagConfigurationStore = flagConfigurationStore;
     this.banditVariationConfigurationStore = banditVariationConfigurationStore;
     this.banditModelConfigurationStore = banditModelConfigurationStore;
-    this.overridesStore = overridesStore;
+    this.overrideStore = overrideStore;
     this.configurationRequestParameters = configurationRequestParameters;
     this.isObfuscated = isObfuscated;
   }
@@ -205,18 +205,18 @@ export default class EppoClient {
     this.isObfuscated = isObfuscated;
   }
 
-  setOverridesStore(store: ISyncStore<Variation>): void {
-    this.overridesStore = store;
+  setOverrideStore(store: ISyncStore<Variation>): void {
+    this.overrideStore = store;
   }
 
-  unsetOverridesStore(): void {
-    this.overridesStore = undefined;
+  unsetOverrideStore(): void {
+    this.overrideStore = undefined;
   }
 
   // Returns a mapping of flag key to variation key for all active overrides
   getOverrideVariationKeys(): Record<string, string> {
     return Object.fromEntries(
-      Object.entries(this.overridesStore?.entries() ?? {}).map(([flagKey, value]) => [
+      Object.entries(this.overrideStore?.entries() ?? {}).map(([flagKey, value]) => [
         flagKey,
         value.key,
       ]),
@@ -971,7 +971,7 @@ export default class EppoClient {
     validateNotBlank(flagKey, 'Invalid argument: flagKey cannot be blank');
 
     const flagEvaluationDetailsBuilder = this.newFlagEvaluationDetailsBuilder(flagKey);
-    const overrideVariation = this.overridesStore?.get(flagKey);
+    const overrideVariation = this.overrideStore?.get(flagKey);
     if (overrideVariation) {
       return overrideResult(
         flagKey,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -957,8 +957,7 @@ export default class EppoClient {
     validateNotBlank(flagKey, 'Invalid argument: flagKey cannot be blank');
 
     const flagEvaluationDetailsBuilder = this.newFlagEvaluationDetailsBuilder(flagKey);
-
-    const overrideVariation = this.overridesStore?.get(getMD5Hash(flagKey));
+    const overrideVariation = this.overridesStore?.get(flagKey);
     if (overrideVariation) {
       const configFormat = this.overridesStore?.getFormat() ?? '';
       const flagEvaluationDetails = flagEvaluationDetailsBuilder

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -213,6 +213,16 @@ export default class EppoClient {
     this.overridesStore = undefined;
   }
 
+  // Returns a mapping of flag key to variation key for all active overrides
+  getOverrideVariationKeys(): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries(this.overridesStore?.entries() ?? {}).map(([flagKey, value]) => [
+        flagKey,
+        value.key,
+      ]),
+    );
+  }
+
   async fetchFlagConfigurations() {
     if (!this.configurationRequestParameters) {
       throw new Error(

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -963,11 +963,12 @@ export default class EppoClient {
     const flagEvaluationDetailsBuilder = this.newFlagEvaluationDetailsBuilder(flagKey);
     const overrideVariation = this.overridesStore?.get(flagKey);
     if (overrideVariation) {
+      const overrideAllocationKey = 'override-' + overrideVariation.key;
       const flagEvaluationDetails = flagEvaluationDetailsBuilder
         .setMatch(
           0,
           overrideVariation,
-          { key: overrideVariation.key, splits: [], doLog: false },
+          { key: overrideAllocationKey, splits: [], doLog: false },
           null,
           undefined,
         )

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -956,11 +956,11 @@ export default class EppoClient {
     validateNotBlank(subjectKey, 'Invalid argument: subjectKey cannot be blank');
     validateNotBlank(flagKey, 'Invalid argument: flagKey cannot be blank');
 
-    // Check for override early
+    const flagEvaluationDetailsBuilder = this.newFlagEvaluationDetailsBuilder(flagKey);
+
     const overrideVariation = this.overridesStore?.get(getMD5Hash(flagKey));
     if (overrideVariation) {
       const configFormat = this.overridesStore?.getFormat() ?? '';
-      const flagEvaluationDetailsBuilder = this.newFlagEvaluationDetailsBuilder(flagKey);
       const flagEvaluationDetails = flagEvaluationDetailsBuilder
         .setMatch(
           0,
@@ -984,7 +984,6 @@ export default class EppoClient {
       };
     }
 
-    const flagEvaluationDetailsBuilder = this.newFlagEvaluationDetailsBuilder(flagKey);
     const configDetails = this.getConfigDetails();
     const flag = this.getFlag(flagKey);
 

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -30,7 +30,7 @@ import {
 } from '../constants';
 import { decodeFlag } from '../decoding';
 import { EppoValue } from '../eppo_value';
-import { Evaluator, FlagEvaluation, noneResult } from '../evaluator';
+import { Evaluator, FlagEvaluation, noneResult, overrideResult } from '../evaluator';
 import { BoundedEventQueue } from '../events/bounded-event-queue';
 import EventDispatcher from '../events/event-dispatcher';
 import NoOpEventDispatcher from '../events/no-op-event-dispatcher';
@@ -963,28 +963,13 @@ export default class EppoClient {
     const flagEvaluationDetailsBuilder = this.newFlagEvaluationDetailsBuilder(flagKey);
     const overrideVariation = this.overridesStore?.get(flagKey);
     if (overrideVariation) {
-      const overrideAllocationKey = 'override-' + overrideVariation.key;
-      const flagEvaluationDetails = flagEvaluationDetailsBuilder
-        .setMatch(
-          0,
-          overrideVariation,
-          { key: overrideAllocationKey, splits: [], doLog: false },
-          null,
-          undefined,
-        )
-        .build('MATCH', 'Flag override applied');
-
-      return {
+      return overrideResult(
         flagKey,
         subjectKey,
-        variation: overrideVariation,
         subjectAttributes,
-        flagEvaluationDetails,
-        doLog: false,
-        format: '',
-        allocationKey: 'override',
-        extraLogging: {},
-      };
+        overrideVariation,
+        flagEvaluationDetailsBuilder,
+      );
     }
 
     const configDetails = this.getConfigDetails();

--- a/src/client/eppo-precomputed-client.spec.ts
+++ b/src/client/eppo-precomputed-client.spec.ts
@@ -12,7 +12,7 @@ import {
   ensureNonContextualSubjectAttributes,
 } from '../attributes';
 import { IPrecomputedConfigurationResponse } from '../configuration';
-import { IConfigurationStore } from '../configuration-store/configuration-store';
+import { IConfigurationStore, ISyncStore } from '../configuration-store/configuration-store';
 import { MemoryOnlyConfigurationStore } from '../configuration-store/memory.store';
 import { DEFAULT_POLL_INTERVAL_MS, MAX_EVENT_QUEUE_SIZE, POLL_JITTER_PCT } from '../constants';
 import FetchHttpClient from '../http-client';
@@ -20,6 +20,7 @@ import {
   FormatEnum,
   IObfuscatedPrecomputedBandit,
   PrecomputedFlag,
+  Variation,
   VariationType,
 } from '../interfaces';
 import { decodeBase64, encodeBase64, getMD5Hash } from '../obfuscation';
@@ -1025,5 +1026,251 @@ describe('Precomputed Bandit Store', () => {
 
     loggerErrorSpy.mockRestore();
     loggerWarnSpy.mockRestore();
+  });
+});
+
+describe('flag overrides', () => {
+  let client: EppoPrecomputedClient;
+  let mockLogger: IAssignmentLogger;
+  let overridesStore: ISyncStore<Variation>;
+  let flagStorage: IConfigurationStore<PrecomputedFlag>;
+  let subject: Subject;
+
+  const precomputedFlagKey = 'mock-flag';
+  const hashedPrecomputedFlagKey = getMD5Hash(precomputedFlagKey);
+
+  const mockPrecomputedFlag: PrecomputedFlag = {
+    flagKey: hashedPrecomputedFlagKey,
+    variationKey: encodeBase64('a'),
+    variationValue: encodeBase64('variation-a'),
+    allocationKey: encodeBase64('allocation-a'),
+    doLog: true,
+    variationType: VariationType.STRING,
+    extraLogging: {},
+  };
+
+  beforeEach(() => {
+    flagStorage = new MemoryOnlyConfigurationStore();
+    flagStorage.setEntries({ [hashedPrecomputedFlagKey]: mockPrecomputedFlag });
+    mockLogger = td.object<IAssignmentLogger>();
+    overridesStore = new MemoryOnlyConfigurationStore<Variation>();
+    subject = {
+      subjectKey: 'test-subject',
+      subjectAttributes: { attr1: 'value1' },
+    };
+
+    client = new EppoPrecomputedClient({
+      precomputedFlagStore: flagStorage,
+      subject,
+      overridesStore,
+    });
+    client.setAssignmentLogger(mockLogger);
+  });
+
+  it('returns override values for all supported types', () => {
+    overridesStore.setEntries({
+      'string-flag': {
+        key: 'override-variation',
+        value: 'override-string',
+      },
+      'boolean-flag': {
+        key: 'override-variation',
+        value: true,
+      },
+      'numeric-flag': {
+        key: 'override-variation',
+        value: 42.5,
+      },
+      'json-flag': {
+        key: 'override-variation',
+        value: '{"foo": "bar"}',
+      },
+    });
+
+    expect(client.getStringAssignment('string-flag', 'default')).toBe('override-string');
+    expect(client.getBooleanAssignment('boolean-flag', false)).toBe(true);
+    expect(client.getNumericAssignment('numeric-flag', 0)).toBe(42.5);
+    expect(client.getJSONAssignment('json-flag', {})).toEqual({ foo: 'bar' });
+  });
+
+  it('does not log assignments when override is applied', () => {
+    overridesStore.setEntries({
+      [precomputedFlagKey]: {
+        key: 'override-variation',
+        value: 'override-value',
+      },
+    });
+
+    client.getStringAssignment(precomputedFlagKey, 'default');
+
+    expect(td.explain(mockLogger.logAssignment).callCount).toBe(0);
+  });
+
+  it('uses normal assignment when no override exists for flag', () => {
+    // Set override for a different flag
+    overridesStore.setEntries({
+      'other-flag': {
+        key: 'override-variation',
+        value: 'override-value',
+      },
+    });
+
+    const result = client.getStringAssignment(precomputedFlagKey, 'default');
+
+    // Should get the normal assignment value from mockPrecomputedFlag
+    expect(result).toBe('variation-a');
+    expect(td.explain(mockLogger.logAssignment).callCount).toBe(1);
+  });
+
+  it('uses normal assignment when no overrides store is configured', () => {
+    // Create client without overrides store
+    const clientWithoutOverrides = new EppoPrecomputedClient({
+      precomputedFlagStore: flagStorage,
+      subject,
+    });
+    clientWithoutOverrides.setAssignmentLogger(mockLogger);
+
+    const result = clientWithoutOverrides.getStringAssignment(precomputedFlagKey, 'default');
+
+    // Should get the normal assignment value from mockPrecomputedFlag
+    expect(result).toBe('variation-a');
+    expect(td.explain(mockLogger.logAssignment).callCount).toBe(1);
+  });
+
+  it('respects override after initial assignment without override', () => {
+    // First call without override
+    const initialAssignment = client.getStringAssignment(precomputedFlagKey, 'default');
+    expect(initialAssignment).toBe('variation-a');
+    expect(td.explain(mockLogger.logAssignment).callCount).toBe(1);
+
+    // Set override and make second call
+    overridesStore.setEntries({
+      [precomputedFlagKey]: {
+        key: 'override-variation',
+        value: 'override-value',
+      },
+    });
+
+    const overriddenAssignment = client.getStringAssignment(precomputedFlagKey, 'default');
+    expect(overriddenAssignment).toBe('override-value');
+    // No additional logging should occur when using override
+    expect(td.explain(mockLogger.logAssignment).callCount).toBe(1);
+  });
+
+  it('reverts to normal assignment after removing override', () => {
+    // Set initial override
+    overridesStore.setEntries({
+      [precomputedFlagKey]: {
+        key: 'override-variation',
+        value: 'override-value',
+      },
+    });
+
+    const overriddenAssignment = client.getStringAssignment(precomputedFlagKey, 'default');
+    expect(overriddenAssignment).toBe('override-value');
+    expect(td.explain(mockLogger.logAssignment).callCount).toBe(0);
+
+    // Remove override and make second call
+    overridesStore.setEntries({});
+
+    const normalAssignment = client.getStringAssignment(precomputedFlagKey, 'default');
+    expect(normalAssignment).toBe('variation-a');
+    // Should log the normal assignment
+    expect(td.explain(mockLogger.logAssignment).callCount).toBe(1);
+  });
+
+  describe('setOverridesStore', () => {
+    it('applies overrides after setting store', () => {
+      // Create client without overrides store
+      const clientWithoutOverrides = new EppoPrecomputedClient({
+        precomputedFlagStore: flagStorage,
+        subject,
+      });
+      clientWithoutOverrides.setAssignmentLogger(mockLogger);
+
+      // Initial call without override store
+      const initialAssignment = clientWithoutOverrides.getStringAssignment(
+        precomputedFlagKey,
+        'default',
+      );
+      expect(initialAssignment).toBe('variation-a');
+      expect(td.explain(mockLogger.logAssignment).callCount).toBe(1);
+
+      // Set overrides store with override
+      overridesStore.setEntries({
+        [precomputedFlagKey]: {
+          key: 'override-variation',
+          value: 'override-value',
+        },
+      });
+      clientWithoutOverrides.setOverridesStore(overridesStore);
+
+      // Call after setting override store
+      const overriddenAssignment = clientWithoutOverrides.getStringAssignment(
+        precomputedFlagKey,
+        'default',
+      );
+      expect(overriddenAssignment).toBe('override-value');
+      // No additional logging should occur when using override
+      expect(td.explain(mockLogger.logAssignment).callCount).toBe(1);
+    });
+
+    it('reverts to normal assignment after unsetting store', () => {
+      // Set initial override
+      overridesStore.setEntries({
+        [precomputedFlagKey]: {
+          key: 'override-variation',
+          value: 'override-value',
+        },
+      });
+
+      client.getStringAssignment(precomputedFlagKey, 'default');
+      expect(td.explain(mockLogger.logAssignment).callCount).toBe(0);
+
+      // Unset overrides store
+      client.unsetOverridesStore();
+
+      const normalAssignment = client.getStringAssignment(precomputedFlagKey, 'default');
+      expect(normalAssignment).toBe('variation-a');
+      // Should log the normal assignment
+      expect(td.explain(mockLogger.logAssignment).callCount).toBe(1);
+    });
+
+    it('switches between different override stores', () => {
+      // Create a second override store
+      const secondOverridesStore = new MemoryOnlyConfigurationStore<Variation>();
+
+      // Set up different overrides in each store
+      overridesStore.setEntries({
+        [precomputedFlagKey]: {
+          key: 'override-1',
+          value: 'value-1',
+        },
+      });
+
+      secondOverridesStore.setEntries({
+        [precomputedFlagKey]: {
+          key: 'override-2',
+          value: 'value-2',
+        },
+      });
+
+      // Start with first override store
+      const firstOverride = client.getStringAssignment(precomputedFlagKey, 'default');
+      expect(firstOverride).toBe('value-1');
+      expect(td.explain(mockLogger.logAssignment).callCount).toBe(0);
+
+      // Switch to second override store
+      client.setOverridesStore(secondOverridesStore);
+      const secondOverride = client.getStringAssignment(precomputedFlagKey, 'default');
+      expect(secondOverride).toBe('value-2');
+      expect(td.explain(mockLogger.logAssignment).callCount).toBe(0);
+
+      // Switch back to first override store
+      client.setOverridesStore(overridesStore);
+      const backToFirst = client.getStringAssignment(precomputedFlagKey, 'default');
+      expect(backToFirst).toBe('value-1');
+      expect(td.explain(mockLogger.logAssignment).callCount).toBe(0);
+    });
   });
 });

--- a/src/client/eppo-precomputed-client.ts
+++ b/src/client/eppo-precomputed-client.ts
@@ -61,7 +61,7 @@ export type PrecomputedFlagsRequestParameters = {
 interface EppoPrecomputedClientOptions {
   precomputedFlagStore: IConfigurationStore<PrecomputedFlag>;
   precomputedBanditStore?: IConfigurationStore<IObfuscatedPrecomputedBandit>;
-  overridesStore?: ISyncStore<Variation>;
+  overrideStore?: ISyncStore<Variation>;
   subject: Subject;
   banditActions?: Record<FlagKey, Record<string, ContextAttributes>>;
   requestParameters?: PrecomputedFlagsRequestParameters;
@@ -83,12 +83,12 @@ export default class EppoPrecomputedClient {
   private banditActions?: Record<FlagKey, Record<string, ContextAttributes>>;
   private precomputedFlagStore: IConfigurationStore<PrecomputedFlag>;
   private precomputedBanditStore?: IConfigurationStore<IObfuscatedPrecomputedBandit>;
-  private overridesStore?: ISyncStore<Variation>;
+  private overrideStore?: ISyncStore<Variation>;
 
   public constructor(options: EppoPrecomputedClientOptions) {
     this.precomputedFlagStore = options.precomputedFlagStore;
     this.precomputedBanditStore = options.precomputedBanditStore;
-    this.overridesStore = options.overridesStore;
+    this.overrideStore = options.overrideStore;
 
     const { subjectKey, subjectAttributes } = options.subject;
     this.subject = {
@@ -204,7 +204,7 @@ export default class EppoPrecomputedClient {
   ): T {
     validateNotBlank(flagKey, 'Invalid argument: flagKey cannot be blank');
 
-    const overrideVariation = this.overridesStore?.get(flagKey);
+    const overrideVariation = this.overrideStore?.get(flagKey);
     if (overrideVariation) {
       return valueTransformer(overrideVariation.value);
     }
@@ -526,11 +526,11 @@ export default class EppoPrecomputedClient {
     };
   }
 
-  public setOverridesStore(store: ISyncStore<Variation>): void {
-    this.overridesStore = store;
+  public setOverrideStore(store: ISyncStore<Variation>): void {
+    this.overrideStore = store;
   }
 
-  public unsetOverridesStore(): void {
-    this.overridesStore = undefined;
+  public unsetOverrideStore(): void {
+    this.overrideStore = undefined;
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,4 +15,3 @@ export const NULL_SENTINEL = 'EPPO_NULL';
 export const MAX_EVENT_QUEUE_SIZE = 100;
 export const BANDIT_ASSIGNMENT_SHARDS = 10000;
 export const DEFAULT_TLRU_TTL_MS = 600_000;
-export const OVERRIDES_KEY = 'eppo-overrides';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,3 +15,4 @@ export const NULL_SENTINEL = 'EPPO_NULL';
 export const MAX_EVENT_QUEUE_SIZE = 100;
 export const BANDIT_ASSIGNMENT_SHARDS = 10000;
 export const DEFAULT_TLRU_TTL_MS = 600_000;
+export const OVERRIDES_KEY = 'eppo-overrides';

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -259,3 +259,34 @@ export function matchesRules(
         matchedRule: null,
       };
 }
+
+export function overrideResult(
+  flagKey: string,
+  subjectKey: string,
+  subjectAttributes: Attributes,
+  overrideVariation: Variation,
+  flagEvaluationDetailsBuilder: FlagEvaluationDetailsBuilder,
+): FlagEvaluation {
+  const overrideAllocationKey = 'override-' + overrideVariation.key;
+  const flagEvaluationDetails = flagEvaluationDetailsBuilder
+    .setMatch(
+      0,
+      overrideVariation,
+      { key: overrideAllocationKey, splits: [], doLog: false },
+      null,
+      undefined,
+    )
+    .build('MATCH', 'Flag override applied');
+
+  return {
+    flagKey,
+    subjectKey,
+    variation: overrideVariation,
+    subjectAttributes,
+    flagEvaluationDetails,
+    doLog: false,
+    format: '',
+    allocationKey: overrideAllocationKey,
+    extraLogging: {},
+  };
+}


### PR DESCRIPTION
If overrides have been supplied, use those instead of evaluating rules. Leverages a user-supplied configuration store if present, which may be backed by memory or local storage.