### PR TITLE
feat: publish tagged release when a pre-release version is published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,12 +33,22 @@ jobs:
       - run: yarn install
       - run: yarn test
 
-      - uses: JS-DevTools/npm-publish@v3
+      - name: Publish Latest
+        uses: JS-DevTools/npm-publish@v3
         if: ${{ !github.event.release.prerelease && !steps.version.outputs.prerelease }}
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
           dry-run: true
+
+      - name: Publish Prelease
+        uses: JS-DevTools/npm-publish@v3
+        if: ${{ steps.version.outputs.prerelease }}
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: public
+          dry-run: true
+          tag: ${{ steps.version.outputs.prerelease }}
 
       - name: Upload npm debug log
         if: failure()  # This step will run only if the previous steps failed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,21 +2,35 @@ name: Publish to NPM
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - tp/**
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Parse version from tag
+        id: version
+        uses: release-kit/semver@v2
+        with:
+          fallback: 'v7.1.0-alpha+1'
+
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
       - run: yarn install
       - run: yarn test
+
       - uses: JS-DevTools/npm-publish@v3
+        if: "!github.event.release.prerelease"  
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
+          dry_run: true
+
       - name: Upload npm debug log
         if: failure()  # This step will run only if the previous steps failed
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,6 @@ name: Publish to NPM
 on:
   release:
     types: [published]
-  push:
-    branches:
-      - tp/**
 
 jobs:
   publish:
@@ -15,17 +12,25 @@ jobs:
       - name: Parse version from tag
         id: version
         uses: release-kit/semver@v2
-        with:
-          source: latest-tag
-          fallback: 'v7.1.0-alpha.1'
-      - name: Display semver components
+
+      - name: Display Release Plan
+        if: ${{ !github.event.release.prerelease && !steps.version.outputs.prerelease }
         run: |
-          echo "${{ steps.version.outputs.major }}"
-          echo "${{ steps.version.outputs.minor }}"
-          echo "${{ steps.version.outputs.patch }}"
-          echo "${{ steps.version.outputs.prerelease }}"
-          echo "${{ steps.version.outputs.build }}"
-          echo "${{ steps.version.outputs.full }}"
+          echo "Publishing release ${{ steps.version.outputs.full }}"
+
+      - name: Display Pre-release Plan
+        if: ${{ github.event.release.prerelease && steps.version.outputs.prerelease }
+        run: |
+          echo "Publishing pre-relese ${{ steps.version.outputs.full }}"
+
+      # - name: Display semver components
+      #   run: |
+      #     echo "${{ steps.version.outputs.major }}"
+      #     echo "${{ steps.version.outputs.minor }}"
+      #     echo "${{ steps.version.outputs.patch }}"
+      #     echo "${{ steps.version.outputs.prerelease }}"
+      #     echo "${{ steps.version.outputs.build }}"
+      #     echo "${{ steps.version.outputs.full }}"
           
       - uses: actions/setup-node@v3
         with:
@@ -39,7 +44,6 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
-          dry-run: true
 
       - name: Publish Pre-release
         uses: JS-DevTools/npm-publish@v3
@@ -47,7 +51,6 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
-          dry-run: true
           tag: ${{ steps.version.outputs.prerelease }}
 
       - name: Upload npm debug log

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,8 @@ jobs:
         uses: release-kit/semver@v2
         with:
           source: latest-tag
-          fallback: 'v7.1.0-alpha+1'
-      - name: Use parsed version
+          fallback: 'v7.1.0-alpha.1'
+      - name: Display semver components
         run: |
           echo "${{ steps.version.outputs.major }}"
           echo "${{ steps.version.outputs.minor }}"
@@ -41,9 +41,9 @@ jobs:
           access: public
           dry-run: true
 
-      - name: Publish Prelease
+      - name: Publish Pre-release
         uses: JS-DevTools/npm-publish@v3
-        if: ${{ steps.version.outputs.prerelease }}
+        if: ${{ github.event.release.prerelease && steps.version.outputs.prerelease }}
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,17 @@ jobs:
         id: version
         uses: release-kit/semver@v2
         with:
+          source: latest-tag
           fallback: 'v7.1.0-alpha+1'
-
+      - name: Use parsed version
+        run: |
+          echo "${{ steps.version.outputs.major }}"
+          echo "${{ steps.version.outputs.minor }}"
+          echo "${{ steps.version.outputs.patch }}"
+          echo "${{ steps.version.outputs.prerelease }}"
+          echo "${{ steps.version.outputs.build }}"
+          echo "${{ steps.version.outputs.full }}"
+          
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,11 +34,11 @@ jobs:
       - run: yarn test
 
       - uses: JS-DevTools/npm-publish@v3
-        if: "!github.event.release.prerelease"  
+        if: ${{ !github.event.release.prerelease && !steps.version.outputs.prerelease }}
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
-          dry_run: true
+          dry-run: true
 
       - name: Upload npm debug log
         if: failure()  # This step will run only if the previous steps failed


### PR DESCRIPTION

## Motivation and Context
Automation of pre-release deployments

## Description
- don't publish as latest if the workflow is "pre-release" or there's a pre-release label in the version string
- Publish a tagged version (i.e. "alpha.1") if the pre-release checkbox is checked AND the github tag/semver has a pre-release label in it.

EX:
- Create a release, leave "latest" checked and give it a tag of `v4.3.5` => a release will be published to NPM and tagged `latest`
- Create a release, v4.3.5-alpha.1, create a release with "pre-release" checked and a release will be published to NPM and tagged `alpha.1`
- Create a release with pre-release checked but no pre-release label in the tag, or a pre-release label in the tag, but a "latest" version and nothing will happen (a message will be printed"