### PR TITLE
Handle special characters when decoding obfuscated configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/configuration-requestor.ts
+++ b/src/configuration-requestor.ts
@@ -1,14 +1,7 @@
 import { IConfigurationStore } from './configuration-store/configuration-store';
 import { hydrateConfigurationStore } from './configuration-store/configuration-store-utils';
 import { IHttpClient } from './http-client';
-import {
-  BanditVariation,
-  BanditParameters,
-  Flag,
-  BanditReference,
-} from './interfaces';
-
-type Entry = Flag | BanditVariation[] | BanditParameters;
+import { BanditVariation, BanditParameters, Flag, BanditReference } from './interfaces';
 
 // Requests AND stores flag configurations
 export default class ConfigurationRequestor {
@@ -63,7 +56,8 @@ export default class ConfigurationRequestor {
             entries: banditResponse.bandits,
             environment: configResponse.environment,
             createdAt: configResponse.createdAt,
-            format: configResponse.format,});
+            format: configResponse.format,
+          });
 
           this.banditModelVersions = this.getLoadedBanditModelVersionsFromStore(
             this.banditModelConfigurationStore,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -142,6 +142,7 @@ export class Evaluator {
         configDetails.configFormat,
       );
     } catch (err: any) {
+      console.error('>>>>', err);
       const flagEvaluationDetails = flagEvaluationDetailsBuilder.gracefulBuild(
         'ASSIGNMENT_ERROR',
         `Assignment Error: ${err.message}`,

--- a/src/events/default-event-dispatcher.spec.ts
+++ b/src/events/default-event-dispatcher.spec.ts
@@ -12,6 +12,7 @@ global.fetch = jest.fn();
 
 const mockNetworkStatusListener = {
   isOffline: () => false,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onNetworkStatusChange: (_: (_: boolean) => void) => null as unknown as void,
 };
 
@@ -154,6 +155,7 @@ describe('DefaultEventDispatcher', () => {
   describe('offline handling', () => {
     it('skips delivery when offline', async () => {
       let isOffline = false;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       let cb = (_: boolean) => null as unknown as void;
       const networkStatusListener = {
         isOffline: () => isOffline,
@@ -188,6 +190,7 @@ describe('DefaultEventDispatcher', () => {
 
     it('resumes delivery when back online', async () => {
       let isOffline = true;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       let cb = (_: boolean) => null as unknown as void;
       const networkStatusListener = {
         isOffline: () => isOffline,

--- a/src/events/no-op-event-dispatcher.ts
+++ b/src/events/no-op-event-dispatcher.ts
@@ -2,6 +2,7 @@ import Event from './event';
 import EventDispatcher from './event-dispatcher';
 
 export default class NoOpEventDispatcher implements EventDispatcher {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   dispatch(_: Event): void {
     // Do nothing
   }

--- a/src/flag-evaluation-details-builder.ts
+++ b/src/flag-evaluation-details-builder.ts
@@ -11,7 +11,7 @@ export const flagEvaluationCodes = [
   'BANDIT_ERROR',
 ] as const;
 
-export type FlagEvaluationCode = typeof flagEvaluationCodes[number];
+export type FlagEvaluationCode = (typeof flagEvaluationCodes)[number];
 
 export enum AllocationEvaluationCode {
   UNEVALUATED = 'UNEVALUATED',

--- a/src/obfuscation.spec.ts
+++ b/src/obfuscation.spec.ts
@@ -17,6 +17,15 @@ describe('obfuscation', () => {
     });
   });
 
+  it('encodes/decodes special characters', () => {
+    const strings = ['kümmert', 'заботится', '照顾', '🤗🌸'];
+
+    strings.forEach((string) => {
+      expect(decodeBase64(encodeBase64(string))).toEqual(string);
+      expect(decodeBase64(encodeBase64(string))).toEqual(string);
+    });
+  });
+
   describe('salt', () => {
     it('converts from bytes to base64 string', () => {
       const chars = new Uint8Array([101, 112, 112, 111]); // eppo

--- a/src/obfuscation.spec.ts
+++ b/src/obfuscation.spec.ts
@@ -18,12 +18,14 @@ describe('obfuscation', () => {
   });
 
   it('encodes/decodes special characters', () => {
-    const strings = ['kümmert', 'заботится', '照顾', '🤗🌸'];
+    const strings = ['kümmert', 'піклуватися', '照顾', '🤗🌸'];
 
     strings.forEach((string) => {
       expect(decodeBase64(encodeBase64(string))).toEqual(string);
       expect(decodeBase64(encodeBase64(string))).toEqual(string);
     });
+
+    expect(decodeBase64('a8O8bW1lcnQ=')).toEqual('kümmert');
   });
 
   describe('salt', () => {

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -1,5 +1,5 @@
 import base64 = require('js-base64');
-import * as SparkMD5 from 'spark-md5';
+import SparkMD5 from 'spark-md5';
 
 import { PrecomputedFlag } from './interfaces';
 
@@ -8,11 +8,11 @@ export function getMD5Hash(input: string, salt = ''): string {
 }
 
 export function encodeBase64(input: string) {
-  return base64.btoaPolyfill(input);
+  return base64.encode(input);
 }
 
 export function decodeBase64(input: string) {
-  return base64.atobPolyfill(input);
+  return base64.decode(input);
 }
 
 export function obfuscatePrecomputedFlags(

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -1,5 +1,5 @@
 import base64 = require('js-base64');
-import SparkMD5 from 'spark-md5';
+import * as SparkMD5 from 'spark-md5';
 
 import { PrecomputedFlag } from './interfaces';
 

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -5,6 +5,7 @@ import { IAssignmentDetails } from '../src/client/eppo-client';
 import { IFlagEvaluationDetails } from '../src/flag-evaluation-details-builder';
 import { IBanditParametersResponse, IUniversalFlagConfigResponse } from '../src/http-client';
 import { ContextAttributes } from '../src/types';
+import { isEqual } from 'lodash';
 
 export const TEST_DATA_DIR = './test/data/ufc/';
 export const ASSIGNMENT_TEST_DATA_DIR = TEST_DATA_DIR + 'tests/';
@@ -125,16 +126,17 @@ export function validateTestAssignments(
   flag: string,
 ) {
   for (const { subject, assignment } of assignments) {
-    if (typeof assignment !== 'object') {
-      // the expect works well for objects, but this comparison does not
-      if (assignment !== subject.assignment) {
-        throw new Error(
-          `subject ${
-            subject.subjectKey
-          } was assigned ${assignment?.toString()} when expected ${subject.assignment?.toString()} for flag ${flag}`,
-        );
-      }
+    if (!isEqual(assignment, subject.assignment)) {
+      // More friendly error message
+      console.error(
+        `subject ${subject.subjectKey} was assigned ${JSON.stringify(
+          assignment,
+          undefined,
+          2,
+        )} when expected ${JSON.stringify(subject.assignment, undefined, 2)} for flag ${flag}`,
+      );
     }
-    expect(subject.assignment).toEqual(assignment);
+
+    expect(assignment).toEqual(subject.assignment);
   }
 }

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -1,11 +1,10 @@
 import * as fs from 'fs';
 
-import { AttributeType, VariationType } from '../src';
-import { IAssignmentDetails } from '../src/client/eppo-client';
+import { isEqual } from 'lodash';
+
+import { AttributeType, ContextAttributes, IAssignmentDetails, VariationType } from '../src';
 import { IFlagEvaluationDetails } from '../src/flag-evaluation-details-builder';
 import { IBanditParametersResponse, IUniversalFlagConfigResponse } from '../src/http-client';
-import { ContextAttributes } from '../src/types';
-import { isEqual } from 'lodash';
 
 export const TEST_DATA_DIR = './test/data/ufc/';
 export const ASSIGNMENT_TEST_DATA_DIR = TEST_DATA_DIR + 'tests/';


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-3763 - Update shared SDK test data to have a test case for special characters](https://linear.app/eppo/issue/FF-3763/update-shared-sdk-test-data-to-have-a-test-case-for-special-characters)
🗨️ **Slack Thread:** ["...flag text encoding problem..."](https://eppo-group.slack.com/archives/C0541NTN6QH/p1735566355776199)

## Motivation and Context
The JavaScript core library currently does not handle special, non-ASCII characters.

## Description
We switch from using [`js-base64`](https://www.npmjs.com/package/js-base64)'s `btoaPolyfill()` and `atobPolyfill()` to `encode` and `decode` respectively.

The former is designed only to handle ASCII characters and bytes ([docs](https://github.com/dankogai/js-base64?tab=readme-ov-file#decode-vs-atob-and-encode-vs-btoa)), while the latter is designed for strings and can handle all characters. 

## How has this been tested?
* Added a test case to `obfuscation.spec`
  ![image](https://github.com/user-attachments/assets/a0d6456d-2808-4cdf-a765-9e90e812ad7c)
* Tried out [pending](https://github.com/Eppo-exp/sdk-test-data/pull/103) special character shared test data changes
  ![image](https://github.com/user-attachments/assets/eb8f8d91-830e-4743-bcc4-52862cc88f29)