### PR TITLE
chore: adjust precomputed assignments export for node environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "buffer": "npm:@eppo/buffer@6.2.0",
     "js-base64": "^3.7.7",
     "pino": "^9.5.0",
+    "react-native-get-random-values": "^1.11.0",
     "semver": "^7.5.4",
     "spark-md5": "^3.0.2",
     "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.8.0-alpha.0",
+  "version": "4.8.0-alpha.1",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -214,7 +214,7 @@ describe('EppoClient E2E test', () => {
     });
 
     it('skips disabled flags', () => {
-      const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {});
+      const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {}, false);
       const { precomputed } = JSON.parse(encodedPrecomputedWire) as IConfigurationWire;
       if (!precomputed) {
         fail('Precomputed data not in Configuration response');
@@ -229,7 +229,7 @@ describe('EppoClient E2E test', () => {
     });
 
     it('evaluates and returns assignments', () => {
-      const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {});
+      const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {}, false);
       const { precomputed } = JSON.parse(encodedPrecomputedWire) as IConfigurationWire;
       if (!precomputed) {
         fail('Precomputed data not in Configuration response');
@@ -248,7 +248,7 @@ describe('EppoClient E2E test', () => {
       // Use a known salt to produce deterministic hashes
       setSaltOverrideForTests(new Uint8Array([7, 53, 17, 78]));
 
-      const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {}, true);
+      const encodedPrecomputedWire = client.getPrecomputedAssignments('subject', {});
       const { precomputed } = JSON.parse(encodedPrecomputedWire) as IConfigurationWire;
       if (!precomputed) {
         fail('Precomputed data not in Configuration response');

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -871,7 +871,7 @@ export default class EppoClient {
   getPrecomputedAssignments(
     subjectKey: string,
     subjectAttributes: Attributes | ContextAttributes = {},
-    obfuscated = false,
+    obfuscated = true,
   ): string {
     const configDetails = this.getConfigDetails();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import {
 import { HybridConfigurationStore } from './configuration-store/hybrid.store';
 import { MemoryStore, MemoryOnlyConfigurationStore } from './configuration-store/memory.store';
 import * as constants from './constants';
+import { decodePrecomputedFlag } from './decoding';
 import BatchEventProcessor from './events/batch-event-processor';
 import { BoundedEventQueue } from './events/bounded-event-queue';
 import DefaultEventDispatcher, {
@@ -47,6 +48,7 @@ import NamedEventQueue from './events/named-event-queue';
 import NetworkStatusListener from './events/network-status-listener';
 import HttpClient from './http-client';
 import { PrecomputedFlag, Flag, ObfuscatedFlag, VariationType, FormatEnum } from './interfaces';
+import { setSaltOverrideForTests } from './obfuscation';
 import {
   AttributeType,
   Attributes,
@@ -125,4 +127,8 @@ export {
   IConfigurationWire,
   IPrecomputedConfigurationResponse,
   PrecomputedFlag,
+
+  // Test helpers
+  setSaltOverrideForTests,
+  decodePrecomputedFlag,
 };

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -9,6 +9,13 @@ let getRandomValues: (length: number) => Uint8Array;
 if (typeof window !== 'undefined' && window.crypto) {
   // Browser environment
   getRandomValues = (length: number) => window.crypto.getRandomValues(new Uint8Array(length));
+} else if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
+  // React Native environment
+  require('react-native-get-random-values');
+  getRandomValues = (length: number) => {
+    const array = new Uint8Array(length);
+    return window.crypto.getRandomValues(array);
+  };
 } else {
   // Node.js environment
   import('crypto')
@@ -17,7 +24,7 @@ if (typeof window !== 'undefined' && window.crypto) {
       return;
     })
     .catch((error) => {
-      logger.error('Failed to load crypto module:', error);
+      logger.error('[Eppo SDK] Failed to load crypto module:', error);
     });
 }
 

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -1,7 +1,25 @@
 import base64 = require('js-base64');
 import * as SparkMD5 from 'spark-md5';
 
+import { logger } from './application-logger';
 import { PrecomputedFlag } from './interfaces';
+
+// Import randomBytes according to the environment
+let getRandomValues: (length: number) => Uint8Array;
+if (typeof window !== 'undefined' && window.crypto) {
+  // Browser environment
+  getRandomValues = (length: number) => window.crypto.getRandomValues(new Uint8Array(length));
+} else {
+  // Node.js environment
+  import('crypto')
+    .then((crypto) => {
+      getRandomValues = (length: number) => new Uint8Array(crypto.randomBytes(length));
+      return;
+    })
+    .catch((error) => {
+      logger.error('Failed to load crypto module:', error);
+    });
+}
 
 export function getMD5Hash(input: string, salt = ''): string {
   return new SparkMD5().append(salt).append(input).end();
@@ -49,7 +67,5 @@ export function setSaltOverrideForTests(salt: Uint8Array | null) {
 }
 
 export function generateSalt(length = 16): string {
-  return base64.fromUint8Array(
-    saltOverrideBytes ? saltOverrideBytes : crypto.getRandomValues(new Uint8Array(length)),
-  );
+  return base64.fromUint8Array(saltOverrideBytes ? saltOverrideBytes : getRandomValues(length));
 }

--- a/src/react-native-get-random-values.d.ts
+++ b/src/react-native-get-random-values.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-native-get-random-values';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,11 @@
     "outDir": "dist",
     "noImplicitAny": true,
     "strict": true,
-    "strictPropertyInitialization": true
+    "strictPropertyInitialization": true,
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "node_modules",
     "dist",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,9 @@ module.exports = {
     fallback: {
       crypto: false, // Exclude crypto module in the browser bundle
     },
+    alias: {
+      'react-native-get-random-values': false, // Ignore this module in non-React Native environments
+    },
   },
   output: {
     filename: 'eppo-sdk.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,9 @@ module.exports = {
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
+    fallback: {
+      crypto: false, // Exclude crypto module in the browser bundle
+    },
   },
   output: {
     filename: 'eppo-sdk.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2194,6 +2194,11 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
+fast-base64-decode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
+  integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3930,6 +3935,13 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-native-get-random-values@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz#1ca70d1271f4b08af92958803b89dccbda78728d"
+  integrity sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==
+  dependencies:
+    fast-base64-decode "^1.0.0"
 
 real-require@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

A method for exporting precomputed assignments was added to the common sdk https://github.com/Eppo-exp/js-sdk-common/pull/160 and published in [version 4.7.1](https://github.com/Eppo-exp/js-sdk-common/releases/tag/v4.7.1)

The end-user would use the function in the node SDK and so I checked that it works in the node environment. I found a couple things to improve:

* `crypto` needs to be imported in node, the common sdk assumes it is a globally scoped variable which is only true in the browser environment
* the common sdk is hard coded to assume that precomputed assignments in the configuration wire are obfuscated, so that should be the default format

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Locally with `yarn link` and running the test I created in https://github.com/Eppo-exp/node-server-sdk/pull/89

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
