### PR TITLE
chore: remove dependency on crypto module in common

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "buffer": "npm:@eppo/buffer@6.2.0",
     "js-base64": "^3.7.7",
     "pino": "^9.5.0",
-    "react-native-get-random-values": "^1.11.0",
     "semver": "^7.5.4",
     "spark-md5": "^3.0.2",
     "uuid": "^8.3.2"

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -1,3 +1,5 @@
+import * as base64 from 'js-base64';
+
 import {
   readMockUFCResponse,
   MOCK_BANDIT_MODELS_RESPONSE_FILE,
@@ -24,7 +26,7 @@ import {
 } from '../flag-evaluation-details-builder';
 import FetchHttpClient from '../http-client';
 import { BanditVariation, BanditParameters, Flag } from '../interfaces';
-import { attributeEncodeBase64, setSaltOverrideForTests } from '../obfuscation';
+import { attributeEncodeBase64 } from '../obfuscation';
 import { Attributes, BanditActions, ContextAttributes } from '../types';
 
 import EppoClient, { IAssignmentDetails } from './eppo-client';
@@ -658,10 +660,12 @@ describe('EppoClient Bandits E2E test', () => {
       subjectAttributes: ContextAttributes,
       banditActions: Record<string, BanditActions>,
     ): IPrecomputedConfiguration {
+      const salt = base64.fromUint8Array(new Uint8Array([101, 112, 112, 111]));
       const precomputedResults = client.getPrecomputedConfiguration(
         subjectKey,
         subjectAttributes,
         banditActions,
+        salt,
       );
 
       const { precomputed } = JSON.parse(precomputedResults) as IConfigurationWire;
@@ -672,14 +676,6 @@ describe('EppoClient Bandits E2E test', () => {
     }
 
     describe('obfuscated results', () => {
-      beforeEach(() => {
-        setSaltOverrideForTests(new Uint8Array([101, 112, 112, 111])); // e p p o => "ZXBwbw=="
-      });
-
-      afterAll(() => {
-        setSaltOverrideForTests(null);
-      });
-
       it('obfuscates precomputed bandits', () => {
         const bannerBanditFlagMd5 = '3ac89e06235484aa6f2aec8c33109a02';
         const brandAffinityB64 = 'YnJhbmRfYWZmaW5pdHk=';

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -866,12 +866,14 @@ export default class EppoClient {
    *
    * @param subjectKey an identifier of the experiment subject, for example a user ID.
    * @param subjectAttributes optional attributes associated with the subject, for example name and email.
-   * @param banditActions
+   * @param banditActions optional attributes associated with the bandit actions
+   * @param salt a salt to use for obfuscation
    */
   getPrecomputedConfiguration(
     subjectKey: string,
     subjectAttributes: Attributes | ContextAttributes = {},
     banditActions: Record<FlagKey, BanditActions> = {},
+    salt = '',
   ): string {
     const configDetails = this.getConfigDetails();
 
@@ -890,6 +892,7 @@ export default class EppoClient {
       subjectKey,
       flags,
       bandits,
+      salt,
       subjectContextualAttributes,
       configDetails.configEnvironment,
     );

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -873,8 +873,11 @@ export default class EppoClient {
     subjectKey: string,
     subjectAttributes: Attributes | ContextAttributes = {},
     banditActions: Record<FlagKey, BanditActions> = {},
-    salt = '',
+    salt?: string,
   ): string {
+    if (!salt) {
+      throw new Error('[Eppo SDK] Salt is required for precomputed configuration');
+    }
     const configDetails = this.getConfigDetails();
 
     const subjectContextualAttributes = ensureContextualSubjectAttributes(subjectAttributes);

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -875,9 +875,6 @@ export default class EppoClient {
     banditActions: Record<FlagKey, BanditActions> = {},
     salt?: string,
   ): string {
-    if (!salt) {
-      throw new Error('[Eppo SDK] Salt is required for precomputed configuration');
-    }
     const configDetails = this.getConfigDetails();
 
     const subjectContextualAttributes = ensureContextualSubjectAttributes(subjectAttributes);
@@ -895,7 +892,7 @@ export default class EppoClient {
       subjectKey,
       flags,
       bandits,
-      salt,
+      salt ?? '', // no salt if not provided
       subjectContextualAttributes,
       configDetails.configEnvironment,
     );

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -5,11 +5,7 @@ import {
   IPrecomputedBandit,
   PrecomputedFlag,
 } from './interfaces';
-import {
-  generateSalt,
-  obfuscatePrecomputedBanditMap,
-  obfuscatePrecomputedFlags,
-} from './obfuscation';
+import { obfuscatePrecomputedBanditMap, obfuscatePrecomputedFlags } from './obfuscation';
 import { ContextAttributes, FlagKey, HashedFlagKey } from './types';
 
 // Base interface for all configuration responses
@@ -69,6 +65,7 @@ export class PrecomputedConfiguration implements IPrecomputedConfiguration {
     subjectKey: string,
     flags: Record<FlagKey, PrecomputedFlag>,
     bandits: Record<FlagKey, IPrecomputedBandit>,
+    salt: string,
     subjectAttributes?: ContextAttributes,
     environment?: Environment,
   ): IPrecomputedConfiguration {
@@ -76,6 +73,7 @@ export class PrecomputedConfiguration implements IPrecomputedConfiguration {
       subjectKey,
       flags,
       bandits,
+      salt,
       subjectAttributes,
       environment,
     );
@@ -132,12 +130,13 @@ export class ObfuscatedPrecomputedConfigurationResponse
     subjectKey: string,
     flags: Record<FlagKey, PrecomputedFlag>,
     bandits: Record<FlagKey, IPrecomputedBandit>,
+    salt: string,
     subjectAttributes?: ContextAttributes,
     environment?: Environment,
   ) {
     super(subjectKey, subjectAttributes, environment);
 
-    this.salt = generateSalt();
+    this.salt = salt;
     this.bandits = obfuscatePrecomputedBanditMap(this.salt, bandits);
     this.flags = obfuscatePrecomputedFlags(this.salt, flags);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,6 @@ import NamedEventQueue from './events/named-event-queue';
 import NetworkStatusListener from './events/network-status-listener';
 import HttpClient from './http-client';
 import { PrecomputedFlag, Flag, ObfuscatedFlag, VariationType, FormatEnum } from './interfaces';
-import { setSaltOverrideForTests } from './obfuscation';
 import {
   AttributeType,
   Attributes,
@@ -129,6 +128,5 @@ export {
   PrecomputedFlag,
 
   // Test helpers
-  setSaltOverrideForTests,
   decodePrecomputedFlag,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,15 @@ import EventDispatcher from './events/event-dispatcher';
 import NamedEventQueue from './events/named-event-queue';
 import NetworkStatusListener from './events/network-status-listener';
 import HttpClient from './http-client';
-import { PrecomputedFlag, Flag, ObfuscatedFlag, VariationType, FormatEnum } from './interfaces';
+import {
+  PrecomputedFlag,
+  Flag,
+  ObfuscatedFlag,
+  VariationType,
+  FormatEnum,
+  BanditParameters,
+  BanditVariation,
+} from './interfaces';
 import {
   AttributeType,
   Attributes,
@@ -107,6 +115,8 @@ export {
   ContextAttributes,
   BanditSubjectAttributes,
   BanditActions,
+  BanditVariation,
+  BanditParameters,
   Subject,
   FormatEnum,
 

--- a/src/obfuscation.spec.ts
+++ b/src/obfuscation.spec.ts
@@ -1,4 +1,4 @@
-import { decodeBase64, encodeBase64, generateSalt, setSaltOverrideForTests } from './obfuscation';
+import { decodeBase64, encodeBase64 } from './obfuscation';
 
 describe('obfuscation', () => {
   it('encodes strings to base64', () => {
@@ -26,15 +26,5 @@ describe('obfuscation', () => {
     });
 
     expect(decodeBase64('a8O8bW1lcnQ=')).toEqual('kümmert');
-  });
-
-  describe('salt', () => {
-    it('converts from bytes to base64 string', () => {
-      const chars = new Uint8Array([101, 112, 112, 111]); // eppo
-      setSaltOverrideForTests(chars);
-
-      const salt64 = generateSalt();
-      expect(salt64).toEqual('ZXBwbw==');
-    });
   });
 });

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -9,13 +9,6 @@ let getRandomValues: (length: number) => Uint8Array;
 if (typeof window !== 'undefined' && window.crypto) {
   // Browser environment
   getRandomValues = (length: number) => window.crypto.getRandomValues(new Uint8Array(length));
-} else if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
-  // React Native environment
-  require('react-native-get-random-values');
-  getRandomValues = (length: number) => {
-    const array = new Uint8Array(length);
-    return window.crypto.getRandomValues(array);
-  };
 } else {
   // Node.js environment
   import('crypto')
@@ -24,7 +17,7 @@ if (typeof window !== 'undefined' && window.crypto) {
       return;
     })
     .catch((error) => {
-      logger.error('[Eppo SDK] Failed to load crypto module:', error);
+      logger.error('Failed to load crypto module:', error);
     });
 }
 

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -17,7 +17,7 @@ if (typeof window !== 'undefined' && window.crypto) {
       return;
     })
     .catch((error) => {
-      logger.error('Failed to load crypto module:', error);
+      logger.error('[Eppo SDK] Failed to load crypto module:', error);
     });
 }
 

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -1,26 +1,8 @@
 import base64 = require('js-base64');
 import * as SparkMD5 from 'spark-md5';
 
-import { logger } from './application-logger';
 import { IObfuscatedPrecomputedBandit, IPrecomputedBandit, PrecomputedFlag } from './interfaces';
 import { Attributes, AttributeType, Base64String, MD5String } from './types';
-
-// Import randomBytes according to the environment
-let getRandomValues: (length: number) => Uint8Array;
-if (typeof window !== 'undefined' && window.crypto) {
-  // Browser environment
-  getRandomValues = (length: number) => window.crypto.getRandomValues(new Uint8Array(length));
-} else {
-  // Node.js environment
-  import('crypto')
-    .then((crypto) => {
-      getRandomValues = (length: number) => new Uint8Array(crypto.randomBytes(length));
-      return;
-    })
-    .catch((error) => {
-      logger.error('[Eppo SDK] Failed to load crypto module:', error);
-    });
-}
 
 export function getMD5Hash(input: string, salt = ''): string {
   return new SparkMD5().append(salt).append(input).end();
@@ -102,13 +84,4 @@ export function obfuscatePrecomputedFlags(
     };
   });
   return response;
-}
-
-let saltOverrideBytes: Uint8Array | null;
-export function setSaltOverrideForTests(salt: Uint8Array | null) {
-  saltOverrideBytes = salt ? salt : null;
-}
-
-export function generateSalt(length = 16): string {
-  return base64.fromUint8Array(saltOverrideBytes ? saltOverrideBytes : getRandomValues(length));
 }

--- a/src/react-native-get-random-values.d.ts
+++ b/src/react-native-get-random-values.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-native-get-random-values';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,9 @@
     "outDir": "dist",
     "noImplicitAny": true,
     "strict": true,
-    "strictPropertyInitialization": true,
+    "strictPropertyInitialization": true
   },
-  "include": [
-    "src/**/*.ts"
-  ],
+  "include": ["src/**/*.ts"],
   "exclude": [
     "node_modules",
     "dist",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,9 +19,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
-    fallback: {
-      crypto: false, // Exclude crypto module in the browser bundle
-    },
   },
   output: {
     filename: 'eppo-sdk.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,9 +22,6 @@ module.exports = {
     fallback: {
       crypto: false, // Exclude crypto module in the browser bundle
     },
-    alias: {
-      'react-native-get-random-values': false, // Ignore this module in non-React Native environments
-    },
   },
   output: {
     filename: 'eppo-sdk.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2194,11 +2194,6 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-fast-base64-decode@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
-  integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
-
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3935,13 +3930,6 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
-react-native-get-random-values@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz#1ca70d1271f4b08af92958803b89dccbda78728d"
-  integrity sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==
-  dependencies:
-    fast-base64-decode "^1.0.0"
 
 real-require@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

This reverts commit 12f29832b2022099052c2c738dab28822864a7a7 and changes where we generate the salt to the node server sdk: https://github.com/Eppo-exp/node-server-sdk/pull/89/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80.

Removes salt generation code from the common sdk, so we don't need to worry about supporting the `crypto` module in all environments where this is run: js in a browser, node in a server, and react native.

We only need the ability to generate the precomputed configuration in the node server sdk, so I adjusted `getPrecomputedConfiguration` to accept a `salt` argument which we can set in the node server sdk.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
