### PR TITLE
fix: check that config store is initialized before skipping fetch

### DIFF
--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -757,6 +757,9 @@ describe('EppoClient E2E test', () => {
       it('Continues to poll when cache has not expired', async () => {
         class MockStore<T> extends MemoryOnlyConfigurationStore<T> {
           public static expired = false;
+          public isInitialized(): boolean {
+            return true;
+          }
 
           async isExpired(): Promise<boolean> {
             return MockStore.expired;
@@ -790,6 +793,10 @@ describe('EppoClient E2E test', () => {
     });
     it('Does not fetch configurations if the configuration store is unexpired', async () => {
       class MockStore<T> extends MemoryOnlyConfigurationStore<T> {
+        public isInitialized(): boolean {
+          return true;
+        }
+
         async isExpired(): Promise<boolean> {
           return false;
         }

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -216,7 +216,10 @@ export default class EppoClient {
     );
 
     const pollingCallback = async () => {
-      if (await this.flagConfigurationStore.isExpired()) {
+      if (
+        !this.flagConfigurationStore.isInitialized() ||
+        (await this.flagConfigurationStore.isExpired())
+      ) {
         return configurationRequestor.fetchAndStoreConfigurations();
       }
     };


### PR DESCRIPTION
towards FF-3708