### PR TITLE
Revert "fix: check that config store is initialized before skipping fetch"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -766,9 +766,6 @@ describe('EppoClient E2E test', () => {
       it('Continues to poll when cache has not expired', async () => {
         class MockStore<T> extends MemoryOnlyConfigurationStore<T> {
           public static expired = false;
-          public isInitialized(): boolean {
-            return true;
-          }
 
           async isExpired(): Promise<boolean> {
             return MockStore.expired;
@@ -802,10 +799,6 @@ describe('EppoClient E2E test', () => {
     });
     it('Does not fetch configurations if the configuration store is unexpired', async () => {
       class MockStore<T> extends MemoryOnlyConfigurationStore<T> {
-        public isInitialized(): boolean {
-          return true;
-        }
-
         async isExpired(): Promise<boolean> {
           return false;
         }

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -218,10 +218,7 @@ export default class EppoClient {
     );
 
     const pollingCallback = async () => {
-      if (
-        !this.flagConfigurationStore.isInitialized() ||
-        (await this.flagConfigurationStore.isExpired())
-      ) {
+      if (await this.flagConfigurationStore.isExpired()) {
         return configurationRequestor.fetchAndStoreConfigurations();
       }
     };


### PR DESCRIPTION
Reverts Eppo-exp/js-sdk-common#193

## Context
Breaks tests in downstream SDKs.
The `initialized` boolean more accurately indicates "a fetch has written entries to this persistent store in this instance/javascript frame"

## Description
- Reverts #193
- bumps patch version.