### PR TITLE
decode obfuscated bandit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.8.2",
+  "version": "4.8.3-alpha.1",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-precomputed-client.ts
+++ b/src/client/eppo-precomputed-client.ts
@@ -18,7 +18,7 @@ import {
   MAX_EVENT_QUEUE_SIZE,
   PRECOMPUTED_BASE_URL,
 } from '../constants';
-import { decodePrecomputedFlag } from '../decoding';
+import { decodePrecomputedBandit, decodePrecomputedFlag } from '../decoding';
 import { FlagEvaluationWithoutDetails } from '../evaluator';
 import FetchHttpClient from '../http-client';
 import {
@@ -361,10 +361,13 @@ export default class EppoPrecomputedClient {
     return this.getObfuscatedPrecomputedBandit(banditKey);
   }
 
-  private getObfuscatedPrecomputedBandit(banditKey: string): IObfuscatedPrecomputedBandit | null {
+  private getObfuscatedPrecomputedBandit(banditKey: string): IPrecomputedBandit | null {
     const salt = this.precomputedBanditStore?.salt;
     const saltedAndHashedBanditKey = getMD5Hash(banditKey, salt);
-    return this.precomputedBanditStore?.get(saltedAndHashedBanditKey) ?? null;
+    const precomputedBandit: IObfuscatedPrecomputedBandit | null = this.precomputedBanditStore?.get(
+      saltedAndHashedBanditKey,
+    ) as IObfuscatedPrecomputedBandit;
+    return precomputedBandit ? decodePrecomputedBandit(precomputedBandit) : null;
   }
 
   public isInitialized() {

--- a/src/decoding.ts
+++ b/src/decoding.ts
@@ -11,6 +11,8 @@ import {
   ObfuscatedSplit,
   PrecomputedFlag,
   DecodedPrecomputedFlag,
+  IPrecomputedBandit,
+  IObfuscatedPrecomputedBandit,
 } from './interfaces';
 import { decodeBase64 } from './obfuscation';
 
@@ -86,5 +88,18 @@ export function decodePrecomputedFlag(precomputedFlag: PrecomputedFlag): Decoded
     variationKey: decodeBase64(precomputedFlag.variationKey ?? ''),
     variationValue: decodeValue(precomputedFlag.variationValue, precomputedFlag.variationType),
     extraLogging: decodeObject(precomputedFlag.extraLogging ?? {}),
+  };
+}
+
+export function decodePrecomputedBandit(
+  precomputedBandit: IObfuscatedPrecomputedBandit,
+): IPrecomputedBandit {
+  return {
+    ...precomputedBandit,
+    banditKey: decodeBase64(precomputedBandit.banditKey),
+    action: decodeBase64(precomputedBandit.action),
+    modelVersion: decodeBase64(precomputedBandit.modelVersion),
+    actionNumericAttributes: decodeObject(precomputedBandit.actionNumericAttributes ?? {}),
+    actionCategoricalAttributes: decodeObject(precomputedBandit.actionCategoricalAttributes ?? {}),
   };
 }


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

While dogfooding the bandit in the web platform, it was observed that the `actions` field was returned obfuscated. We are missing decoding of the provided configuration.

## Description
[//]: # (Describe your changes in detail)

Decodes the obfuscated bandit on request; matches behavior of flags.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
