### PR TITLE
feat: move `buildStorageKeySuffix`  function to common and bump release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.8.4",
+  "version": "4.9.0",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ import {
   Variation,
   Environment,
 } from './interfaces';
+import { buildStorageKeySuffix } from './obfuscation';
 import {
   AttributeType,
   Attributes,
@@ -153,4 +154,7 @@ export {
 
   // Test helpers
   decodePrecomputedFlag,
+
+  // Utilities
+  buildStorageKeySuffix,
 };

--- a/src/obfuscation.spec.ts
+++ b/src/obfuscation.spec.ts
@@ -16,10 +16,10 @@ describe('obfuscation', () => {
   });
 
   it('hashes API keys for storage key suffixes', () => {
-    expect(buildStorageKeySuffix('MYKEY')).toEqual('ea89bd7e7594e5beb91f045b8605b2dc');
-    expect(buildStorageKeySuffix('MYKEY2')).toEqual('3fc4c6f1358c630f0357cae46d798d95');
+    expect(buildStorageKeySuffix('MYKEY')).toEqual('ea89bd7e7594e5be');
+    expect(buildStorageKeySuffix('MYKEY2')).toEqual('3fc4c6f1358c630f');
     expect(buildStorageKeySuffix('fwezo8v7nsotfizw3rtw===.3t wtw4ztwe3tjw8')).toEqual(
-      'cf6c7dcee09875546411d0d9b32f577e',
+      'cf6c7dcee0987554',
     );
   });
 

--- a/src/obfuscation.spec.ts
+++ b/src/obfuscation.spec.ts
@@ -16,10 +16,10 @@ describe('obfuscation', () => {
   });
 
   it('hashes API keys for storage key suffixes', () => {
-    expect(buildStorageKeySuffix('MYKEY')).toEqual('b91f045b8605b2dc');
-    expect(buildStorageKeySuffix('MYKEY2')).toEqual('0357cae46d798d95');
+    expect(buildStorageKeySuffix('MYKEY')).toEqual('ea89bd7e7594e5beb91f045b8605b2dc');
+    expect(buildStorageKeySuffix('MYKEY2')).toEqual('3fc4c6f1358c630f0357cae46d798d95');
     expect(buildStorageKeySuffix('fwezo8v7nsotfizw3rtw===.3t wtw4ztwe3tjw8')).toEqual(
-      '6411d0d9b32f577e',
+      'cf6c7dcee09875546411d0d9b32f577e',
     );
   });
 

--- a/src/obfuscation.spec.ts
+++ b/src/obfuscation.spec.ts
@@ -1,5 +1,5 @@
 import { IPrecomputedBandit } from './interfaces';
-import { decodeBase64, encodeBase64, obfuscatePrecomputedBanditMap } from './obfuscation';
+import { buildStorageKeySuffix, decodeBase64, encodeBase64, obfuscatePrecomputedBanditMap } from './obfuscation';
 
 describe('obfuscation', () => {
   it('encodes strings to base64', () => {
@@ -8,6 +8,12 @@ describe('obfuscation', () => {
 
   it('decodes base64 to string', () => {
     expect(decodeBase64('NS4w')).toEqual('5.0');
+  });
+
+  it('hashes API keys for storage key suffixes', () => {
+    expect(buildStorageKeySuffix('MYKEY')).toEqual('b91f045b8605b2dc');
+    expect(buildStorageKeySuffix('MYKEY2')).toEqual('0357cae46d798d95');
+    expect(buildStorageKeySuffix('fwezo8v7nsotfizw3rtw===.3t wtw4ztwe3tjw8')).toEqual('6411d0d9b32f577e');
   });
 
   it('encodes/decodes regex', () => {

--- a/src/obfuscation.spec.ts
+++ b/src/obfuscation.spec.ts
@@ -1,5 +1,10 @@
 import { IPrecomputedBandit } from './interfaces';
-import { buildStorageKeySuffix, decodeBase64, encodeBase64, obfuscatePrecomputedBanditMap } from './obfuscation';
+import {
+  buildStorageKeySuffix,
+  decodeBase64,
+  encodeBase64,
+  obfuscatePrecomputedBanditMap,
+} from './obfuscation';
 
 describe('obfuscation', () => {
   it('encodes strings to base64', () => {
@@ -13,7 +18,9 @@ describe('obfuscation', () => {
   it('hashes API keys for storage key suffixes', () => {
     expect(buildStorageKeySuffix('MYKEY')).toEqual('b91f045b8605b2dc');
     expect(buildStorageKeySuffix('MYKEY2')).toEqual('0357cae46d798d95');
-    expect(buildStorageKeySuffix('fwezo8v7nsotfizw3rtw===.3t wtw4ztwe3tjw8')).toEqual('6411d0d9b32f577e');
+    expect(buildStorageKeySuffix('fwezo8v7nsotfizw3rtw===.3t wtw4ztwe3tjw8')).toEqual(
+      '6411d0d9b32f577e',
+    );
   });
 
   it('encodes/decodes regex', () => {

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -11,12 +11,12 @@ export function getMD5Hash(input: string, salt = ''): string {
 /**
  * Builds a storage key suffix from an API key.
  * @param apiKey - The API key to build the suffix from
- * @returns A string suffix for storage keys that does not leak the API key
+ * @returns A string suffix for storage keys
  * @public
  */
 export function buildStorageKeySuffix(apiKey: string): string {
-  // Note that we hash the API key and use the last 16 characters of the digest.
-  return new SparkMD5().append(apiKey).end().slice(-16);
+  // Note that we hash the API key and use the digest.
+  return getMD5Hash(apiKey);
 }
 
 export function encodeBase64(input: string) {

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -15,8 +15,9 @@ export function getMD5Hash(input: string, salt = ''): string {
  * @public
  */
 export function buildStorageKeySuffix(apiKey: string): string {
-  // Note that we hash the API key and use the digest.
-  return getMD5Hash(apiKey);
+  // Note that we hash the API key and use the first 16 characters of the digest.
+  const hashed = getMD5Hash(apiKey);
+  return hashed.slice(0, 16);
 }
 
 export function encodeBase64(input: string) {

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -8,6 +8,17 @@ export function getMD5Hash(input: string, salt = ''): string {
   return new SparkMD5().append(salt).append(input).end();
 }
 
+/**
+ * Builds a storage key suffix from an API key.
+ * @param apiKey - The API key to build the suffix from
+ * @returns A string suffix for storage keys that does not leak the API key
+ * @public
+ */
+export function buildStorageKeySuffix(apiKey: string): string {
+  // Note that we hash the API key and use the last 16 characters of the digest.
+  return new SparkMD5().append(apiKey).end().slice(-16);
+}
+
 export function encodeBase64(input: string) {
   return base64.encode(input);
 }


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: FF-3920

## Motivation and Context
This method is used by both react-native and js-client SDKs so rather than duplicate, we'll move it to common. Also, this moves the algorithm to use a hash instead of just slicing the API key to avoid leaking sensitive info. This also makes suffix collisions much less likely
