### PR TITLE
feat: Create and export a type for the EppoClient constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.8.4",
+  "version": "4.9.0",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -93,6 +93,17 @@ export interface IContainerExperiment<T> {
   treatmentVariationEntries: Array<T>;
 }
 
+export type EppoClientParameters = {
+  // Dispatcher for arbitrary, application-level events (not to be confused with Eppo specific assignment
+  // or bandit events). These events are application-specific and captures by EppoClient#track API.
+  eventDispatcher?: EventDispatcher;
+  flagConfigurationStore: IConfigurationStore<Flag | ObfuscatedFlag>;
+  banditVariationConfigurationStore?: IConfigurationStore<BanditVariation[]>;
+  banditModelConfigurationStore?: IConfigurationStore<BanditParameters>;
+  configurationRequestParameters?: FlagConfigurationRequestParameters;
+  isObfuscated?: boolean;
+};
+
 export default class EppoClient {
   private eventDispatcher: EventDispatcher;
   private readonly assignmentEventsQueue: BoundedEventQueue<IAssignmentEvent> =
@@ -121,16 +132,7 @@ export default class EppoClient {
     banditVariationConfigurationStore,
     banditModelConfigurationStore,
     configurationRequestParameters,
-  }: {
-    // Dispatcher for arbitrary, application-level events (not to be confused with Eppo specific assignment
-    // or bandit events). These events are application-specific and captures by EppoClient#track API.
-    eventDispatcher?: EventDispatcher;
-    flagConfigurationStore: IConfigurationStore<Flag | ObfuscatedFlag>;
-    banditVariationConfigurationStore?: IConfigurationStore<BanditVariation[]>;
-    banditModelConfigurationStore?: IConfigurationStore<BanditParameters>;
-    configurationRequestParameters?: FlagConfigurationRequestParameters;
-    isObfuscated?: boolean;
-  }) {
+  }: EppoClientParameters) {
     this.eventDispatcher = eventDispatcher;
     this.flagConfigurationStore = flagConfigurationStore;
     this.banditVariationConfigurationStore = banditVariationConfigurationStore;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
 import { LRUInMemoryAssignmentCache } from './cache/lru-in-memory-assignment-cache';
 import { NonExpiringInMemoryAssignmentCache } from './cache/non-expiring-in-memory-cache-assignment';
 import EppoClient, {
+  EppoClientParameters,
   FlagConfigurationRequestParameters,
   IAssignmentDetails,
   IContainerExperiment,
@@ -84,6 +85,7 @@ export {
   IBanditLogger,
   IBanditEvent,
   IContainerExperiment,
+  EppoClientParameters,
   EppoClient,
   constants,
   ApiEndpoints,


### PR DESCRIPTION
👯‍♀️ Related PRs:
[js-client#166](https://github.com/Eppo-exp/js-client-sdk/pull/166/files)

## Motivation and context
This makes it easier to subclass the `EppoClient` in the downstream SDKs.
