### PR TITLE
feat(events): Add event context

### DIFF
--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -945,28 +945,4 @@ describe('EppoClient E2E test', () => {
       );
     });
   });
-
-  describe('setContext', () => {
-    class MockStore<T> extends MemoryOnlyConfigurationStore<T> {
-      public static expired = false;
-
-      async isExpired(): Promise<boolean> {
-        return MockStore.expired;
-      }
-    };
-
-    it('should throw an error if the value is an object', () => {
-      const client = new EppoClient({ flagConfigurationStore: new MockStore(), });
-      expect(() => client.setContext('foo', {} as any)).toThrow();
-      expect(() => client.setContext('foo', [] as any)).toThrow();
-    });
-
-    it('should not throw an error if the value is a string, number, boolean, or null', () => {
-      const client = new EppoClient({ flagConfigurationStore: new MockStore(), });
-      expect(() => client.setContext('foo', 'bar')).not.toThrow();
-      expect(() => client.setContext('foo', 1)).not.toThrow();
-      expect(() => client.setContext('foo', true)).not.toThrow();
-      expect(() => client.setContext('foo', null)).not.toThrow();
-    });
-  });
 });

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -945,4 +945,28 @@ describe('EppoClient E2E test', () => {
       );
     });
   });
+
+  describe('setContext', () => {
+    class MockStore<T> extends MemoryOnlyConfigurationStore<T> {
+      public static expired = false;
+
+      async isExpired(): Promise<boolean> {
+        return MockStore.expired;
+      }
+    };
+
+    it('should throw an error if the value is an object', () => {
+      const client = new EppoClient({ flagConfigurationStore: new MockStore(), });
+      expect(() => client.setContext('foo', {} as any)).toThrow();
+      expect(() => client.setContext('foo', [] as any)).toThrow();
+    });
+
+    it('should not throw an error if the value is a string, number, boolean, or null', () => {
+      const client = new EppoClient({ flagConfigurationStore: new MockStore(), });
+      expect(() => client.setContext('foo', 'bar')).not.toThrow();
+      expect(() => client.setContext('foo', 1)).not.toThrow();
+      expect(() => client.setContext('foo', true)).not.toThrow();
+      expect(() => client.setContext('foo', null)).not.toThrow();
+    });
+  });
 });

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -173,9 +173,13 @@ export default class EppoClient {
    * given key.
    *
    * @param key - The context entry key.
-   * @param value - The context entry value.
+   * @param value - The context entry value, must be a string, number, boolean, or null. If value is
+   * an object or an array, will throw an ArgumentError.
    */
   setContext(key: string, value: string | number | boolean | null) {
+    if (value && (typeof value === 'object' || Array.isArray(value))) {
+      throw new Error('Context value must be a string, number, boolean, or null');
+    }
     this.eventDispatcher?.attachContext(key, value);
   }
 

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -165,6 +165,20 @@ export default class EppoClient {
     this.eventDispatcher = eventDispatcher;
   }
 
+  /**
+   * Attaches a context to be included with all events dispatched by the EventDispatcher.
+   * The context is delivered as a top-level object in the ingestion request payload.
+   * An existing key can be removed by providing a `null` value.
+   * Calling this method with same key multiple times causes only the last value to be used for the
+   * given key.
+   *
+   * @param key - The context entry key.
+   * @param value - The context entry value.
+   */
+  setContext(key: string, value: string | number | boolean | null) {
+    this.eventDispatcher?.attachContext(key, value);
+  }
+
   // noinspection JSUnusedGlobalSymbols
   setBanditModelConfigurationStore(
     banditModelConfigurationStore: IConfigurationStore<BanditParameters>,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -177,9 +177,6 @@ export default class EppoClient {
    * an object or an array, will throw an ArgumentError.
    */
   setContext(key: string, value: string | number | boolean | null) {
-    if (value && (typeof value === 'object' || Array.isArray(value))) {
-      throw new Error('Context value must be a string, number, boolean, or null');
-    }
     this.eventDispatcher?.attachContext(key, value);
   }
 

--- a/src/events/batch-retry-manager.spec.ts
+++ b/src/events/batch-retry-manager.spec.ts
@@ -19,15 +19,15 @@ describe('BatchRetryManager', () => {
 
   it('should successfully retry and deliver a batch with no failures', async () => {
     mockDelivery.deliver.mockResolvedValueOnce({ failedEvents: [] });
-    const result = await batchRetryManager.retry(mockBatch);
+    const result = await batchRetryManager.retry(mockBatch, {});
     expect(result).toEqual([]);
     expect(mockDelivery.deliver).toHaveBeenCalledTimes(1);
-    expect(mockDelivery.deliver).toHaveBeenCalledWith(mockBatch);
+    expect(mockDelivery.deliver).toHaveBeenCalledWith(mockBatch, {});
   });
 
   it('should retry failed deliveries up to maxRetries times and return last failed batch', async () => {
     mockDelivery.deliver.mockResolvedValue({ failedEvents: [{ id: 'event1' }] });
-    const result = await batchRetryManager.retry(mockBatch);
+    const result = await batchRetryManager.retry(mockBatch, {});
     expect(result).toEqual([{ id: 'event1' }]);
     expect(mockDelivery.deliver).toHaveBeenCalledTimes(maxRetries);
   });
@@ -40,7 +40,7 @@ describe('BatchRetryManager', () => {
 
     jest.useFakeTimers();
 
-    const retryPromise = batchRetryManager.retry(mockBatch);
+    const retryPromise = batchRetryManager.retry(mockBatch, {});
 
     // 1st retry: 100ms
     // 2nd retry: 200ms
@@ -67,7 +67,7 @@ describe('BatchRetryManager', () => {
 
     jest.useFakeTimers();
 
-    const retryPromise = batchRetryManager.retry(mockBatch);
+    const retryPromise = batchRetryManager.retry(mockBatch, {});
     // 100ms + 200ms + 300ms (maxRetryDelayMs) = 600ms
     await jest.advanceTimersByTimeAsync(600);
     const result = await retryPromise;

--- a/src/events/batch-retry-manager.ts
+++ b/src/events/batch-retry-manager.ts
@@ -1,12 +1,12 @@
 import { logger } from '../application-logger';
-import { EventContext } from './default-event-dispatcher';
 
+import { EventContext } from './default-event-dispatcher';
 import Event from './event';
 import { EventDeliveryResult } from './event-delivery';
 
 export interface IEventDelivery {
   deliver(batch: Event[], context: EventContext): Promise<EventDeliveryResult>;
-};
+}
 
 /**
  * Attempts to retry delivering a batch of events to the ingestionUrl up to `maxRetries` times

--- a/src/events/default-event-dispatcher.spec.ts
+++ b/src/events/default-event-dispatcher.spec.ts
@@ -323,7 +323,29 @@ describe('DefaultEventDispatcher', () => {
   });
 
   describe('attachContext', () => {
-    it.only('attaches a context to be included with all events dispatched by this dispatcher', async () => {
+    it('should throw an error if the value is an object', () => {
+      const eventQueue = new ArrayBackedNamedEventQueue<Event>('test-queue');
+      const { dispatcher } = createDispatcher({ maxRetries: 1 }, eventQueue);
+      expect(() => dispatcher.attachContext('foo', {} as any)).toThrow();
+      expect(() => dispatcher.attachContext('foo', [] as any)).toThrow();
+    });
+
+    it('should not throw an error if the value is a string, number, boolean, or null', () => {
+      const eventQueue = new ArrayBackedNamedEventQueue<Event>('test-queue');
+      const { dispatcher } = createDispatcher({ maxRetries: 1 }, eventQueue);
+      expect(() => dispatcher.attachContext('foo', 'bar')).not.toThrow();
+      expect(() => dispatcher.attachContext('foo', 1)).not.toThrow();
+      expect(() => dispatcher.attachContext('foo', true)).not.toThrow();
+      expect(() => dispatcher.attachContext('foo', null)).not.toThrow();
+    });
+
+    it('should throw an error if the context value is too long', () => {
+      const eventQueue = new ArrayBackedNamedEventQueue<Event>('test-queue');
+      const { dispatcher } = createDispatcher({ maxRetries: 1 }, eventQueue);
+      expect(() => dispatcher.attachContext('foo', 'a'.repeat(2049))).toThrow();
+    });
+
+    it('attaches a context to be included with all events dispatched by this dispatcher', async () => {
       const eventQueue = new ArrayBackedNamedEventQueue<Event>('test-queue');
       const { dispatcher } = createDispatcher({ maxRetries: 1 }, eventQueue);
       dispatcher.attachContext('foo', 'bar');

--- a/src/events/default-event-dispatcher.spec.ts
+++ b/src/events/default-event-dispatcher.spec.ts
@@ -1,3 +1,5 @@
+import { v4 as randomUUID } from 'uuid';
+
 import ArrayBackedNamedEventQueue from './array-backed-named-event-queue';
 import BatchEventProcessor from './batch-event-processor';
 import DefaultEventDispatcher, {
@@ -7,7 +9,6 @@ import DefaultEventDispatcher, {
 import Event from './event';
 import NetworkStatusListener from './network-status-listener';
 import NoOpEventDispatcher from './no-op-event-dispatcher';
-import { v4 as randomUUID } from 'uuid';
 
 global.fetch = jest.fn();
 
@@ -362,17 +363,14 @@ describe('DefaultEventDispatcher', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        'http://example.com',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'x-eppo-token': 'test-sdk-key' },
-          body: JSON.stringify({
-            eppo_events: [event],
-            context: { foo: 'bar', baz: 'qux' },
-          }),
-        },
-      );
+      expect(global.fetch).toHaveBeenCalledWith('http://example.com', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-eppo-token': 'test-sdk-key' },
+        body: JSON.stringify({
+          eppo_events: [event],
+          context: { foo: 'bar', baz: 'qux' },
+        }),
+      });
     });
   });
 

--- a/src/events/default-event-dispatcher.ts
+++ b/src/events/default-event-dispatcher.ts
@@ -108,7 +108,7 @@ export default class DefaultEventDispatcher implements EventDispatcher {
   private ensureValidEvent(event: Event) {
     if (JSON.stringify(event).length > MAX_EVENT_SERIALIZED_LENGTH) {
       throw new Error(
-        `Event serialized length exceeds maximum allowed length of #{MAX_EVENT_SERIALIZED_LENGTH}`,
+        `Event serialized length exceeds maximum allowed length of ${MAX_EVENT_SERIALIZED_LENGTH}`,
       );
     }
   }

--- a/src/events/default-event-dispatcher.ts
+++ b/src/events/default-event-dispatcher.ts
@@ -95,14 +95,21 @@ export default class DefaultEventDispatcher implements EventDispatcher {
     if (value && (typeof value === 'object' || Array.isArray(value))) {
       throw new Error('Context value must be a string, number, boolean, or null');
     }
-    if (value && JSON.stringify({ ...this.context, [key]: value }).length > MAX_CONTEXT_SERIALIZED_LENGTH) {
-      throw new Error(`Context value must be less than ${MAX_CONTEXT_SERIALIZED_LENGTH} characters`);
+    if (
+      value &&
+      JSON.stringify({ ...this.context, [key]: value }).length > MAX_CONTEXT_SERIALIZED_LENGTH
+    ) {
+      throw new Error(
+        `Context value must be less than ${MAX_CONTEXT_SERIALIZED_LENGTH} characters`,
+      );
     }
   }
 
   private ensureValidEvent(event: Event) {
     if (JSON.stringify(event).length > MAX_EVENT_SERIALIZED_LENGTH) {
-      throw new Error(`Event serialized length exceeds maximum allowed length of #{MAX_EVENT_SERIALIZED_LENGTH}`);
+      throw new Error(
+        `Event serialized length exceeds maximum allowed length of #{MAX_EVENT_SERIALIZED_LENGTH}`,
+      );
     }
   }
 

--- a/src/events/default-event-dispatcher.ts
+++ b/src/events/default-event-dispatcher.ts
@@ -100,7 +100,7 @@ export default class DefaultEventDispatcher implements EventDispatcher {
       JSON.stringify({ ...this.context, [key]: value }).length > MAX_CONTEXT_SERIALIZED_LENGTH
     ) {
       throw new Error(
-        `Context value must be less than ${MAX_CONTEXT_SERIALIZED_LENGTH} characters`,
+        `The total context size must be less than ${MAX_CONTEXT_SERIALIZED_LENGTH} characters`,
       );
     }
   }

--- a/src/events/event-delivery.spec.ts
+++ b/src/events/event-delivery.spec.ts
@@ -20,19 +20,19 @@ describe('EventDelivery', () => {
   it('should deliver events successfully when response is OK', async () => {
     const mockResponse = { ok: true, json: async () => ({}) };
     (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
-    const result = await eventDelivery.deliver(testBatch);
+    const result = await eventDelivery.deliver(testBatch, {});
     expect(result).toEqual({ failedEvents: [] });
     expect(global.fetch).toHaveBeenCalledWith(ingestionUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'x-eppo-token': sdkKey },
-      body: JSON.stringify({ eppo_events: testBatch }),
+      body: JSON.stringify({ eppo_events: testBatch, context: {} }),
     });
   });
 
   it('should return failed result if response is not OK', async () => {
     const mockResponse = { ok: false };
     (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
-    const result = await eventDelivery.deliver(testBatch);
+    const result = await eventDelivery.deliver(testBatch, {});
     expect(result).toEqual({ failedEvents: testBatch });
   });
 
@@ -40,20 +40,20 @@ describe('EventDelivery', () => {
     const failedEvents = ['1', '2'];
     const mockResponse = { ok: true, json: async () => ({ failed_events: failedEvents }) };
     (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
-    const result = await eventDelivery.deliver(testBatch);
+    const result = await eventDelivery.deliver(testBatch, {});
     expect(result).toEqual({ failedEvents: [testBatch[0], testBatch[1]] });
   });
 
   it('should return success=true if no failed events in the response', async () => {
     const mockResponse = { ok: true, json: async () => ({}) };
     (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
-    const result = await eventDelivery.deliver(testBatch);
+    const result = await eventDelivery.deliver(testBatch, {});
     expect(result).toEqual({ failedEvents: [] });
   });
 
   it('should handle fetch errors gracefully', async () => {
     (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
-    const result = await eventDelivery.deliver(testBatch);
+    const result = await eventDelivery.deliver(testBatch, {});
     expect(result).toEqual({ failedEvents: testBatch });
   });
 });

--- a/src/events/event-delivery.ts
+++ b/src/events/event-delivery.ts
@@ -1,4 +1,6 @@
 import { logger } from '../application-logger';
+import { IEventDelivery } from './batch-retry-manager';
+import { EventContext } from './default-event-dispatcher';
 
 import Event from './event';
 
@@ -6,7 +8,7 @@ export type EventDeliveryResult = {
   failedEvents: Event[];
 };
 
-export default class EventDelivery {
+export default class EventDelivery implements IEventDelivery {
   constructor(
     private readonly sdkKey: string,
     private readonly ingestionUrl: string,
@@ -16,7 +18,7 @@ export default class EventDelivery {
    * Delivers a batch of events to the ingestion URL endpoint. Returns the UUIDs of any events from
    * the batch that failed ingestion.
    */
-  async deliver(batch: Event[]): Promise<EventDeliveryResult> {
+  async deliver(batch: Event[], context: EventContext): Promise<EventDeliveryResult> {
     try {
       logger.info(
         `[EventDispatcher] Delivering batch of ${batch.length} events to ${this.ingestionUrl}...`,
@@ -24,7 +26,7 @@ export default class EventDelivery {
       const response = await fetch(this.ingestionUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'x-eppo-token': this.sdkKey },
-        body: JSON.stringify({ eppo_events: batch }),
+        body: JSON.stringify({ eppo_events: batch, context }),
       });
       if (response.ok) {
         return await this.parseFailedEvents(response, batch);

--- a/src/events/event-delivery.ts
+++ b/src/events/event-delivery.ts
@@ -1,7 +1,7 @@
 import { logger } from '../application-logger';
+
 import { IEventDelivery } from './batch-retry-manager';
 import { EventContext } from './default-event-dispatcher';
-
 import Event from './event';
 
 export type EventDeliveryResult = {

--- a/src/events/event-dispatcher.ts
+++ b/src/events/event-dispatcher.ts
@@ -3,4 +3,15 @@ import Event from './event';
 export default interface EventDispatcher {
   /** Dispatches (enqueues) an event for eventual delivery. */
   dispatch(event: Event): void;
+  /**
+   * Attaches a context to be included with all events dispatched by this dispatcher.
+   * The context is delivered as a top-level object in the ingestion request payload.
+   * An existing key can be removed by providing a `null` value.
+   * Calling this method with same key multiple times causes only the last value to be used for the
+   * given key.
+   *
+   * @param key - The context entry key.
+   * @param value - The context entry value.
+   */
+  attachContext(key: string, value: string | number | boolean | null): void;
 }

--- a/src/events/no-op-event-dispatcher.ts
+++ b/src/events/no-op-event-dispatcher.ts
@@ -2,6 +2,10 @@ import Event from './event';
 import EventDispatcher from './event-dispatcher';
 
 export default class NoOpEventDispatcher implements EventDispatcher {
+  attachContext(key: string, value: string | number | boolean | null): void {
+    // Do nothing
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   dispatch(_: Event): void {
     // Do nothing

--- a/src/events/no-op-event-dispatcher.ts
+++ b/src/events/no-op-event-dispatcher.ts
@@ -2,6 +2,7 @@ import Event from './event';
 import EventDispatcher from './event-dispatcher';
 
 export default class NoOpEventDispatcher implements EventDispatcher {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   attachContext(key: string, value: string | number | boolean | null): void {
     // Do nothing
   }


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: FF-3932

## Motivation and Context
Allow attaching `context` keys and values with events dispatched through the Track API.

## Description
Context are optional "global" key/value pairs associated with all events and delivered with the Track API to the ingestion endpoint.

## How has this been tested?
Wrote tests


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
