### PR TITLE
Spike on server-side flag overrides

### DIFF
--- a/src/override-validator.ts
+++ b/src/override-validator.ts
@@ -1,0 +1,21 @@
+import { TLRUCache } from './cache/tlru-cache';
+
+const FIVE_MUNITES_IN_MS = 5 * 3600 * 1000;
+
+export class OverrideValidator {
+  private validApiKeyCache = new TLRUCache(100, FIVE_MUNITES_IN_MS);
+
+  async validateOverrideApiKey(overrideApiKey: string) {
+    if (this.validApiKeyCache.get(overrideApiKey) === 'true') {
+      return true;
+    }
+    const isValid = await this.sendValidationRequest(overrideApiKey);
+    this.validApiKeyCache.set(overrideApiKey, `${isValid}`);
+    return isValid;
+  }
+
+  private async sendValidationRequest(overrideApiKey: string) {
+    // TODO: Validate API key on public API
+    return true;
+  }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,3 +2,7 @@
 export async function waitForMs(ms: number) {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export function shallowClone<T>(original: T): T {
+  return Object.assign(Object.create(Object.getPrototypeOf(original)), original);
+}


### PR DESCRIPTION
Spike on server-side flag overrides (node-server-sdk)

The security stuff was simpler than I originally thought, so I figured this would be easier (and faster) to convey the approach in a PR rather than a design document. I'm simply looking for high-level feedback on the approach for now.

The idea is that a customer would call `const eppo = await getInstance().withOverrides(req.cookies['eppo-overrides'])` in their own api endpoint handlers to get an instance of EppoClient that applies the overrides when `get*Assignment` functions are called.

The cookie will be set by the chrome extension, and it will contain the API key that will be validated via Eppo's public API server. Token validation will be cached so that Eppo's server does not get spammed by high-volume customers.