### PR TITLE
fix: remove unnecessary precomputed constructor error logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.12.0",
+  "version": "4.12.1-alpha.0",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-precomputed-client.spec.ts
+++ b/src/client/eppo-precomputed-client.spec.ts
@@ -31,7 +31,6 @@ import EppoPrecomputedClient, {
   Subject,
 } from './eppo-precomputed-client';
 
-
 describe('EppoPrecomputedClient E2E test', () => {
   const precomputedConfigurationWire = readMockConfigurationWireResponse(
     MOCK_PRECOMPUTED_WIRE_FILE,
@@ -767,7 +766,6 @@ describe('EppoPrecomputedClient E2E test', () => {
 
     expect(loggedEvent.format).toEqual(FormatEnum.PRECOMPUTED);
   });
-
 
   describe('Constructor logs errors according to the store state', () => {
     let mockError: jest.SpyInstance;

--- a/src/client/eppo-precomputed-client.spec.ts
+++ b/src/client/eppo-precomputed-client.spec.ts
@@ -137,7 +137,7 @@ describe('EppoPrecomputedClient E2E test', () => {
       );
     });
 
-    it('logs error when initialized with store without salt', () => {
+    it('logs errors when constructor receives an uninitialized store without a salt', () => {
       const nonemptyStore = new MemoryOnlyConfigurationStore<PrecomputedFlag>();
       // Incorrectly initialized: no salt, not set to initialized
       jest.spyOn(nonemptyStore, 'getKeys').mockReturnValue(['some-key']);
@@ -153,6 +153,27 @@ describe('EppoPrecomputedClient E2E test', () => {
         '[Eppo SDK] EppoPrecomputedClient requires an initialized precomputedFlagStore if requestParameters are not provided',
       );
       expect(mockError).toHaveBeenCalledWith(
+        '[Eppo SDK] EppoPrecomputedClient requires a precomputedFlagStore with a salt if requestParameters are not provided',
+      );
+    });
+
+    it('only logs initialization error when constructor receives an uninitialized store with salt', () => {
+      const nonemptyStore = new MemoryOnlyConfigurationStore<PrecomputedFlag>();
+      nonemptyStore.salt = 'nacl';
+      // Incorrectly initialized: no salt, not set to initialized
+      jest.spyOn(nonemptyStore, 'getKeys').mockReturnValue(['some-key']);
+
+      new EppoPrecomputedClient({
+        precomputedFlagStore: nonemptyStore,
+        subject: {
+          subjectKey: '',
+          subjectAttributes: {},
+        },
+      });
+      expect(mockError).toHaveBeenCalledWith(
+        '[Eppo SDK] EppoPrecomputedClient requires an initialized precomputedFlagStore if requestParameters are not provided',
+      );
+      expect(mockError).not.toHaveBeenCalledWith(
         '[Eppo SDK] EppoPrecomputedClient requires a precomputedFlagStore with a salt if requestParameters are not provided',
       );
     });

--- a/src/client/eppo-precomputed-client.spec.ts
+++ b/src/client/eppo-precomputed-client.spec.ts
@@ -30,7 +30,7 @@ import EppoPrecomputedClient, {
   PrecomputedFlagsRequestParameters,
   Subject,
 } from './eppo-precomputed-client';
-import { applicationLogger } from '..';
+
 
 describe('EppoPrecomputedClient E2E test', () => {
   const precomputedConfigurationWire = readMockConfigurationWireResponse(
@@ -773,7 +773,7 @@ describe('EppoPrecomputedClient E2E test', () => {
     let mockError: jest.SpyInstance;
 
     beforeEach(() => {
-      mockError = jest.spyOn(applicationLogger, 'error');
+      mockError = jest.spyOn(logger, 'error');
     });
 
     afterEach(() => {

--- a/src/client/eppo-precomputed-client.ts
+++ b/src/client/eppo-precomputed-client.ts
@@ -100,13 +100,21 @@ export default class EppoPrecomputedClient {
       // Online-mode
       this.requestParameters = options.requestParameters;
     } else {
-      // Offline-mode
+      // Offline-mode -- depends on pre-populated IConfigurationStores (flags and bandits) to source configuration.
 
-      // Offline mode depends on pre-populated IConfigurationStores (flags and bandits) to source configuration.
-      if (!this.precomputedFlagStore.isInitialized()) {
-        logger.error(
-          `${loggerPrefix} EppoPrecomputedClient requires an initialized precomputedFlagStore if requestParameters are not provided`,
-        );
+      // Allow an empty precomputedFlagStore to be passed in, but if it has items, ensure it was initialized properly.
+      if (this.precomputedFlagStore.getKeys().length > 0) {
+        if (!this.precomputedFlagStore.isInitialized()) {
+          logger.error(
+            `${loggerPrefix} EppoPrecomputedClient requires an initialized precomputedFlagStore if requestParameters are not provided`,
+          );
+        }
+
+        if (!this.precomputedFlagStore.salt) {
+          logger.error(
+            `${loggerPrefix} EppoPrecomputedClient requires a precomputedFlagStore with a salt if requestParameters are not provided`,
+          );
+        }
       }
 
       if (this.precomputedBanditStore && !this.precomputedBanditStore.isInitialized()) {
@@ -115,11 +123,6 @@ export default class EppoPrecomputedClient {
         );
       }
 
-      if (!this.precomputedFlagStore.salt) {
-        logger.error(
-          `${loggerPrefix} EppoPrecomputedClient requires a precomputedFlagStore with a salt if requestParameters are not provided`,
-        );
-      }
 
       if (this.precomputedBanditStore && !this.precomputedBanditStore.salt) {
         logger.warn(

--- a/src/client/eppo-precomputed-client.ts
+++ b/src/client/eppo-precomputed-client.ts
@@ -123,7 +123,6 @@ export default class EppoPrecomputedClient {
         );
       }
 
-
       if (this.precomputedBanditStore && !this.precomputedBanditStore.salt) {
         logger.warn(
           `${loggerPrefix} EppoPrecomputedClient missing or empty salt for precomputedBanditStore`,


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

There is a place in `EppoPrecomputedJSClient`'s implementation where we want to initialize the instance with an empty store.

https://github.com/Eppo-exp/js-client-sdk/blob/5b317dab2cda07abb8aa259a14e7f88ac1dfc963/src/index.ts#L680-L688

This results in the following two errors getting logged

```
"[Eppo SDK] EppoPrecomputedClient requires an initialized precomputedFlagStore if requestParameters are not provided"
"[Eppo SDK] EppoPrecomputedClient requires a precomputedFlagStore with a salt if requestParameters are not provided"
```

Even if the client isn't even using the precomputed client, since we are initializing it automatically to ensure that `getPrecomputedInstance` always returns an instance.

## Description
[//]: # (Describe your changes in detail)

The change here allows `EppoPrecomputedClient`'s initialization with an empty store without a salt and without the store being set to initialized.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Some unit tests that reproduce what is happening in the `js-client-sdk`

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
