### PR TITLE
fix: key validation should be serverd from https://eppo.cloud

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -3,7 +3,6 @@ import {
   UFC_ENDPOINT,
   BANDIT_ENDPOINT,
   PRECOMPUTED_FLAGS_ENDPOINT,
-  FLAG_OVERRIDES_KEY_VALIDATION_URL,
 } from './constants';
 import { IQueryParams, IQueryParamsWithSubject } from './http-client';
 
@@ -36,9 +35,5 @@ export default class ApiEndpoints {
 
   precomputedFlagsEndpoint(): URL {
     return this.endpoint(PRECOMPUTED_FLAGS_ENDPOINT);
-  }
-
-  flagOverridesKeyValidationEndpoint(): URL {
-    return this.endpoint(FLAG_OVERRIDES_KEY_VALIDATION_URL);
   }
 }

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -213,8 +213,7 @@ export default class EppoClient {
       return undefined;
     }
     const payload: OverridePayload = this.overrideValidator.parseOverridePayload(overridePayload);
-    const baseUrl = this.configurationRequestParameters?.baseUrl;
-    await this.overrideValidator.validateKey(payload.browserExtensionKey, baseUrl);
+    await this.overrideValidator.validateKey(payload.browserExtensionKey);
     return payload.overrides;
   }
 

--- a/src/override-validator.ts
+++ b/src/override-validator.ts
@@ -1,20 +1,17 @@
-import ApiEndpoints from './api-endpoints';
 import { TLRUCache } from './cache/tlru-cache';
 import { Variation } from './interfaces';
 import { FlagKey } from './types';
 
 const FIVE_MINUTES_IN_MS = 5 * 3600 * 1000;
+const KEY_VALIDATION_URL = 'https://eppo.cloud/api/flag-overrides/v1/validate-key';
 
 export interface OverridePayload {
   browserExtensionKey: string;
   overrides: Record<FlagKey, Variation>;
 }
 
-export const sendValidationRequest = async (
-  browserExtensionKey: string,
-  validationEndpoint: string,
-) => {
-  const response = await fetch(validationEndpoint, {
+export const sendValidationRequest = async (browserExtensionKey: string) => {
+  const response = await fetch(KEY_VALIDATION_URL, {
     method: 'POST',
     body: JSON.stringify({
       key: browserExtensionKey,
@@ -66,12 +63,11 @@ export class OverrideValidator {
     }
   }
 
-  async validateKey(browserExtensionKey: string, baseUrl: string | undefined) {
+  async validateKey(browserExtensionKey: string) {
     if (this.validKeyCache.get(browserExtensionKey) === 'true') {
       return true;
     }
-    const endpoint = new ApiEndpoints({ baseUrl }).flagOverridesKeyValidationEndpoint().toString();
-    await sendValidationRequest(browserExtensionKey, endpoint);
+    await sendValidationRequest(browserExtensionKey);
     this.validKeyCache.set(browserExtensionKey, 'true');
   }
 }


### PR DESCRIPTION
Key validation should always be pointed to https://eppo.coud as there is no fscdn equivalent.