### PR TITLE
fix: bandit flag with no allocations incorrectly returning programmatic default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-precomputed-client.ts
+++ b/src/client/eppo-precomputed-client.ts
@@ -327,7 +327,7 @@ export default class EppoPrecomputedClient {
 
     if (banditEvaluation == null) {
       logger.warn(`${loggerPrefix} No assigned variation. Bandit not found: ${flagKey}`);
-      return { variation: defaultValue, action: null };
+      return { variation: this.getStringAssignment(flagKey, defaultValue), action: null };
     }
 
     const assignedVariation = this.getStringAssignment(flagKey, defaultValue);


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: [FF-4105](https://linear.app/eppo/issue/FF-4105)

## Motivation and Context
A bandit flag is not returned in UFC when there are no allocations assigned to it, however the "default variation" is still desired in that scenario. Currently, the programmatic default is used.

## Description
Updates `getBanditAction()` so that it falls back to the flag evaluation if the bandit flag does not exist