### PR TITLE
fix: Network Error in older React Naitve versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.13.4",
+  "version": "4.13.5-alpha1",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -46,9 +46,16 @@ export interface IBanditParametersResponse {
   bandits: Record<string, BanditParameters>;
 }
 
+/**
+ * Fixes issues with url.toString() in older React Native versions
+ * that leaves a trailing slash in pathname
+ * @param url URL to stringify
+ * @returns stringified url
+ */
 const urlWithNoTrailingSlash = (url: URL) => {
-  url.pathname = url.pathname.replace(/\/$/, '');
-  return url.toString();
+  // Note: URL.pathname does not exist in some React Native JS runtime
+  //       so we have to do string manipulation on the stringified URL
+  return url.toString().replace(/\/\?/, '?').replace(/\/$/, '');
 };
 
 export interface IHttpClient {


### PR DESCRIPTION
Fixes issues caused by the implementation of https://github.com/Eppo-exp/js-sdk-common/pull/242 where URL.pathname was not available in older React Native JS runtimes.