### PR TITLE
infra: deprecate edge assignments bespoke URL; route via fscdn.eppo.c…

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,11 +6,10 @@ export const DEFAULT_POLL_INTERVAL_MS = 30000;
 export const POLL_JITTER_PCT = 0.1;
 export const DEFAULT_INITIAL_CONFIG_REQUEST_RETRIES = 1;
 export const DEFAULT_POLL_CONFIG_REQUEST_RETRIES = 7;
-export const BASE_URL = 'https://fscdn.eppo.cloud/api';
-export const UFC_ENDPOINT = '/flag-config/v1/config';
-export const BANDIT_ENDPOINT = '/flag-config/v1/bandits';
-export const PRECOMPUTED_BASE_URL = 'https://fs-edge-assignment.eppo.cloud';
-export const PRECOMPUTED_FLAGS_ENDPOINT = '/assignments';
+export const BASE_URL = 'https://fscdn.eppo.cloud';
+export const UFC_ENDPOINT = '/api/flag-config/v1/config';
+export const BANDIT_ENDPOINT = '/api/flag-config/v1/bandits';
+export const PRECOMPUTED_FLAGS_ENDPOINT = '/edge/assignments';
 export const SESSION_ASSIGNMENT_CONFIG_LOADED = 'eppo-session-assignment-config-loaded';
 export const NULL_SENTINEL = 'EPPO_NULL';
 // number of logging events that may be queued while waiting for initialization


### PR DESCRIPTION
…loud

---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Tidying things up with a change to our routing at the VCL layer; just deployed to production without incident.

**Goals**
* All traffic to edge assignment will go through the existing CDN route - this gives us a consistent SSL cert, request logging, paves the way to easily support off-boarding and provides a clear delineation between edge and origin requests.

**Done**
* Deprecating the https://fs-edge-assignment.eppo.cloud/ domain in favor of serving all traffic through our existing https://fscdn.eppo.cloud/
* All requests to /api are routed to the Eppo origin servers and use the Fastly cache and shielding - no change here except to explicitly make it a catch all for that pattern.
* All requests to /edge go to the edge handler
* Created new routes on the server for /edge/assignments that are handled by the same function
https://github.com/Eppo-exp/eppo/commit/52b7c76c107e723d324b2f0a72702a22f3d32d21

Next steps:
* Updating JS commons, Dart and eppo_core to use the new routing; will be released as a patch to increase customer adoption.
* After traffic stops on the old domain it will be removed

## Description
[//]: # (Describe your changes in detail)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
