### PR TITLE
chore: ban URL due to incompatibilities with React Native's Hermes JS engine

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,12 +48,16 @@ module.exports = {
       {
         name: 'atob',
         message:
-          "'atob' unavailable in React Native 0.72. Use 'decodeBase64' helper in src/obfuscation.ts instead",
+          "'atob' unavailable in React Native's Hermes JS engine. Use 'decodeBase64' helper in src/obfuscation.ts instead",
       },
       {
         name: 'btoa',
         message:
-          "'btoa' unavailable in React Native 0.72. Use 'encodeBase64' helper in src/obfuscation.ts instead",
+          "'btoa' unavailable in React Native's Hermes JS engine. Use 'encodeBase64' helper in src/obfuscation.ts instead",
+      },
+      {
+        name: 'URL',
+        message: "URL is improperly implemented in React Native's Hermes JS engine.",
       },
       {
         name: 'Buffer',

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -17,23 +17,26 @@ export default class ApiEndpoints {
     this.params.baseUrl = params.baseUrl ?? DEFAULT_BASE_URL;
   }
 
-  endpoint(resource: string): URL {
-    const url = new URL(this.params.baseUrl + resource);
-    Object.entries(this.params.queryParams ?? {}).forEach(([key, value]) =>
-      url.searchParams.append(key, value),
-    );
-    return url;
+  endpoint(resource: string): string {
+    const endpointUrl = `${this.params.baseUrl}${resource}`;
+    const queryParams = this.params.queryParams;
+    if (!queryParams) {
+      return endpointUrl;
+    }
+    const urlSearchParams = new URLSearchParams();
+    Object.entries(queryParams).forEach(([key, value]) => urlSearchParams.append(key, value));
+    return `${endpointUrl}?${urlSearchParams}`;
   }
 
-  ufcEndpoint(): URL {
+  ufcEndpoint(): string {
     return this.endpoint(UFC_ENDPOINT);
   }
 
-  banditParametersEndpoint(): URL {
+  banditParametersEndpoint(): string {
     return this.endpoint(BANDIT_ENDPOINT);
   }
 
-  precomputedFlagsEndpoint(): URL {
+  precomputedFlagsEndpoint(): string {
     return this.endpoint(PRECOMPUTED_FLAGS_ENDPOINT);
   }
 }


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: [FF-4133](https://linear.app/eppo/issue/FF-4133/ban-url-instances-in-js-client-sdk-common)

## Motivation and Context
There are a number of issues with the `URL` implementation in React Native's Heremes JavaScript engine:
- URL cannot handle "localhost" domain for base url [react-native#26019](https://github.com/facebook/react-native/issues/26019).
- URL implementation should add a trailing slash to the base [react-native#25717](https://github.com/facebook/react-native/issues/25717).
- URL incorrectly adds trailing slash [react-native#24428](https://github.com/facebook/react-native/issues/24428).
Creating an instance of URL like: new URL('http://facebook.com') throws an exception [react-native#16434](https://github.com/facebook/react-native/issues/16434).
- Many URL fields are unavailable (e.g. `url.pathname`)

## Description
This PR bans usages of URL via eslint and removes the current usage so that it instead uses URLSearchParams.

## How has this been tested?
Tested locally in React Native 0.72