### PR TITLE
infra: add support for decoding configuration hostnames from SDK keys…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,3 @@
----
-labels: mergeable
----
-[//]: #  (Link to the issue corresponding to this chunk of work)
-Fixes: #__issue__
-
 ## Motivation and Context
 [//]: #  (Why is this change required? What problem does it solve?)
 
@@ -13,6 +7,5 @@ Fixes: #__issue__
 ## How has this been tested?
 [//]: # (Please describe in detail how you tested your changes)
 
-
-[//]: # (OPTIONAL)
-[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
+## Documentation
+[//]: # (Does this PR require documentation updates?)

--- a/src/events/sdk-key-decoder.spec.ts
+++ b/src/events/sdk-key-decoder.spec.ts
@@ -1,12 +1,40 @@
+import { Base64 } from 'js-base64';
+
 import SdkKeyDecoder from './sdk-key-decoder';
 
 describe('SdkKeyDecoder', () => {
-  const decoder = new SdkKeyDecoder();
-  it('should decode the event ingestion hostname from the SDK key', () => {
-    const hostname = decoder.decodeEventIngestionUrl(
-      'zCsQuoHJxVPp895.ZWg9MTIzNDU2LmUudGVzdGluZy5lcHBvLmNsb3Vk',
+  let decoder: SdkKeyDecoder;
+  const sdkKeyPrefix = 'zCsQuoHJxVPp895';
+
+  beforeEach(() => {
+    decoder = new SdkKeyDecoder();
+  });
+
+  it('should return null for all URLs when no hosts are encoded', () => {
+    const sdkKey = 'invalid.sdk.key';
+    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBeNull();
+    expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBeNull();
+    expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBeNull();
+  });
+
+  it('should return event ingestion URL when only event ingestion host is encoded', () => {
+    const sdkKey = `${sdkKeyPrefix}.${Base64.encode('eh=123456.e.testing.eppo.cloud')}.signature`;
+    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe(
+      'https://123456.e.testing.eppo.cloud/v0/i',
     );
-    expect(hostname).toEqual('https://123456.e.testing.eppo.cloud/v0/i');
+    expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBeNull();
+    expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBeNull();
+  });
+
+  it('should return assignment configuration URL when only configuration host is encoded', () => {
+    const sdkKey = `${sdkKeyPrefix}.${Base64.encode('ch=123456.c.testing.eppo.cloud')}.signature`;
+    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBeNull();
+    expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBe(
+      'https://123456.c.testing.eppo.cloud/assignment',
+    );
+    expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBe(
+      'https://123456.c.testing.eppo.cloud/edge',
+    );
   });
 
   it('should decode strings with non URL-safe characters', () => {
@@ -17,8 +45,48 @@ describe('SdkKeyDecoder', () => {
     expect(hostname).toEqual('https://12 3456/.e.testing.eppo.cloud/v0/i');
   });
 
-  it("should return null if the SDK key doesn't contain the event ingestion hostname", () => {
-    expect(decoder.decodeEventIngestionUrl('zCsQuoHJxVPp895')).toBeNull();
-    expect(decoder.decodeEventIngestionUrl('zCsQuoHJxVPp895.xxxxxx')).toBeNull();
+  it('should handle malformed SDK keys gracefully', () => {
+    const malformedKeys = [
+      '',
+      'invalid',
+      'invalid.',
+      'invalid.invalid',
+      'invalid.invalid.invalid',
+      `valid.${Base64.encode('invalid=host')}.signature`,
+    ];
+
+    malformedKeys.forEach((key) => {
+      expect(decoder.decodeEventIngestionUrl(key)).toBeNull();
+      expect(decoder.decodeAssignmentConfigurationUrl(key)).toBeNull();
+      expect(decoder.decodeEdgeConfigurationUrl(key)).toBeNull();
+    });
+  });
+
+  it('should handle URLs with existing schemes', () => {
+    const hosts = ['eh=http://event.host', 'ch=https://config.host'].join('&');
+    const sdkKey = `${sdkKeyPrefix}.${Base64.encode(hosts)}.signature`;
+
+    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe('http://event.host/v0/i');
+    expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBe('https://config.host/assignment');
+    expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBe('https://config.host/edge');
+  });
+
+  it('should add https scheme when protocol is missing', () => {
+    const hosts = ['eh=event.host', 'ch=config.host:8080'].join('&');
+    const sdkKey = `${sdkKeyPrefix}.${Base64.encode(hosts)}.signature`;
+
+    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe('https://event.host/v0/i');
+    expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBe(
+      'https://config.host:8080/assignment',
+    );
+    expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBe('https://config.host:8080/edge');
+  });
+
+  it('should handle special characters in URLs', () => {
+    const specialHost = 'eh=test.host/with+special@chars?param=value';
+    const sdkKey = `${sdkKeyPrefix}.${Base64.encode(specialHost)}.signature`;
+    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe(
+      'https://test.host/with special@chars?param=value/v0/i',
+    );
   });
 });

--- a/src/events/sdk-key-decoder.spec.ts
+++ b/src/events/sdk-key-decoder.spec.ts
@@ -10,83 +10,104 @@ describe('SdkKeyDecoder', () => {
     decoder = new SdkKeyDecoder();
   });
 
-  it('should return null for all URLs when no hosts are encoded', () => {
-    const sdkKey = 'invalid.sdk.key';
-    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBeNull();
-    expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBeNull();
-    expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBeNull();
-  });
+  describe('generations of SDK keys', () => {
+    it('should return null for all URLs when no hosts are encoded', () => {
+      const sdkKey = 'invalid.sdk.key';
+      expect(decoder.decodeEventIngestionUrl(sdkKey)).toBeNull();
+      expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBeNull();
+      expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBeNull();
+    });
 
-  it('should return event ingestion URL when only event ingestion host is encoded', () => {
-    const sdkKey = `${sdkKeyPrefix}.${Base64.encode('eh=123456.e.testing.eppo.cloud')}.signature`;
-    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe(
-      'https://123456.e.testing.eppo.cloud/v0/i',
-    );
-    expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBeNull();
-    expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBeNull();
-  });
+    it('should return event ingestion URL when only event ingestion host is encoded', () => {
+      const sdkKey = `${sdkKeyPrefix}.${Base64.encode('eh=123456.e.testing.eppo.cloud')}.signature`;
+      expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe(
+        'https://123456.e.testing.eppo.cloud/v0/i',
+      );
+      expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBeNull();
+      expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBeNull();
+    });
 
-  it('should return assignment configuration URL when only configuration host is encoded', () => {
-    const sdkKey = `${sdkKeyPrefix}.${Base64.encode('ch=123456.c.testing.eppo.cloud')}.signature`;
-    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBeNull();
-    expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBe(
-      'https://123456.c.testing.eppo.cloud/assignment',
-    );
-    expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBe(
-      'https://123456.c.testing.eppo.cloud/edge',
-    );
-  });
+    it('should return assignment configuration URL when only configuration host is encoded', () => {
+      const sdkKey = `${sdkKeyPrefix}.${Base64.encode('ch=123456.fscdn.eppo.cloud')}.signature`;
+      expect(decoder.decodeEventIngestionUrl(sdkKey)).toBeNull();
+      expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBe(
+        'https://123456.fscdn.eppo.cloud/assignment',
+      );
+      expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBe(
+        'https://123456.fscdn.eppo.cloud/edge',
+      );
+    });
 
-  it('should decode strings with non URL-safe characters', () => {
-    // this is not a really valid ingestion URL, but it's useful for testing the decoder
-    const invalidUrl = 'eh=12+3456/.e.testing.eppo.cloud';
-    const encoded = Buffer.from(invalidUrl).toString('base64url');
-    const hostname = decoder.decodeEventIngestionUrl(`zCsQuoHJxVPp895.${encoded}`);
-    expect(hostname).toEqual('https://12 3456/.e.testing.eppo.cloud/v0/i');
-  });
-
-  it('should handle malformed SDK keys gracefully', () => {
-    const malformedKeys = [
-      '',
-      'invalid',
-      'invalid.',
-      'invalid.invalid',
-      'invalid.invalid.invalid',
-      `valid.${Base64.encode('invalid=host')}.signature`,
-    ];
-
-    malformedKeys.forEach((key) => {
-      expect(decoder.decodeEventIngestionUrl(key)).toBeNull();
-      expect(decoder.decodeAssignmentConfigurationUrl(key)).toBeNull();
-      expect(decoder.decodeEdgeConfigurationUrl(key)).toBeNull();
+    it('should return URLs when both hosts are encoded', () => {
+      const sdkKey = `${sdkKeyPrefix}.${Base64.encode(
+        'eh=123456.e.testing.eppo.cloud&ch=123456.fscdn.eppo.cloud',
+      )}.signature`;
+      expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe(
+        'https://123456.e.testing.eppo.cloud/v0/i',
+      );
+      expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBe(
+        'https://123456.fscdn.eppo.cloud/assignment',
+      );
+      expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBe(
+        'https://123456.fscdn.eppo.cloud/edge',
+      );
     });
   });
 
-  it('should handle URLs with existing schemes', () => {
-    const hosts = ['eh=http://event.host', 'ch=https://config.host'].join('&');
-    const sdkKey = `${sdkKeyPrefix}.${Base64.encode(hosts)}.signature`;
+  describe('corner cases', () => {
+    it('should decode strings with non URL-safe characters', () => {
+      // this is not a really valid ingestion URL, but it's useful for testing the decoder
+      const invalidUrl = 'eh=12+3456/.e.testing.eppo.cloud';
+      const encoded = Buffer.from(invalidUrl).toString('base64url');
+      const hostname = decoder.decodeEventIngestionUrl(`zCsQuoHJxVPp895.${encoded}`);
+      expect(hostname).toEqual('https://12 3456/.e.testing.eppo.cloud/v0/i');
+    });
 
-    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe('http://event.host/v0/i');
-    expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBe('https://config.host/assignment');
-    expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBe('https://config.host/edge');
-  });
+    it('should handle malformed SDK keys gracefully', () => {
+      const malformedKeys = [
+        '',
+        'invalid',
+        'invalid.',
+        'invalid.invalid',
+        'invalid.invalid.invalid',
+        `valid.${Base64.encode('invalid=host')}.signature`,
+      ];
 
-  it('should add https scheme when protocol is missing', () => {
-    const hosts = ['eh=event.host', 'ch=config.host:8080'].join('&');
-    const sdkKey = `${sdkKeyPrefix}.${Base64.encode(hosts)}.signature`;
+      malformedKeys.forEach((key) => {
+        expect(decoder.decodeEventIngestionUrl(key)).toBeNull();
+        expect(decoder.decodeAssignmentConfigurationUrl(key)).toBeNull();
+        expect(decoder.decodeEdgeConfigurationUrl(key)).toBeNull();
+      });
+    });
 
-    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe('https://event.host/v0/i');
-    expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBe(
-      'https://config.host:8080/assignment',
-    );
-    expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBe('https://config.host:8080/edge');
-  });
+    it('should handle URLs with existing schemes', () => {
+      const hosts = ['eh=http://event.host', 'ch=https://config.host'].join('&');
+      const sdkKey = `${sdkKeyPrefix}.${Base64.encode(hosts)}.signature`;
 
-  it('should handle special characters in URLs', () => {
-    const specialHost = 'eh=test.host/with+special@chars?param=value';
-    const sdkKey = `${sdkKeyPrefix}.${Base64.encode(specialHost)}.signature`;
-    expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe(
-      'https://test.host/with special@chars?param=value/v0/i',
-    );
+      expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe('http://event.host/v0/i');
+      expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBe(
+        'https://config.host/assignment',
+      );
+      expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBe('https://config.host/edge');
+    });
+
+    it('should add https scheme when protocol is missing', () => {
+      const hosts = ['eh=event.host', 'ch=config.host:8080'].join('&');
+      const sdkKey = `${sdkKeyPrefix}.${Base64.encode(hosts)}.signature`;
+
+      expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe('https://event.host/v0/i');
+      expect(decoder.decodeAssignmentConfigurationUrl(sdkKey)).toBe(
+        'https://config.host:8080/assignment',
+      );
+      expect(decoder.decodeEdgeConfigurationUrl(sdkKey)).toBe('https://config.host:8080/edge');
+    });
+
+    it('should handle special characters in URLs', () => {
+      const specialHost = 'eh=test.host/with+special@chars?param=value';
+      const sdkKey = `${sdkKeyPrefix}.${Base64.encode(specialHost)}.signature`;
+      expect(decoder.decodeEventIngestionUrl(sdkKey)).toBe(
+        'https://test.host/with special@chars?param=value/v0/i',
+      );
+    });
   });
 });

--- a/src/events/sdk-key-decoder.ts
+++ b/src/events/sdk-key-decoder.ts
@@ -1,6 +1,11 @@
 import { Base64 } from 'js-base64';
 
-const PATH = 'v0/i';
+const EVENT_INGESTION_HOSTNAME_KEY = 'eh';
+const CONFIGURATION_HOSTNAME_KEY = 'ch';
+
+const EVENT_INGESTION_PATH = 'v0/i';
+const ASSIGNMENT_CONFIG_PATH = 'assignment';
+const EDGE_CONFIG_PATH = 'edge';
 
 export default class SdkKeyDecoder {
   /**
@@ -8,20 +13,58 @@ export default class SdkKeyDecoder {
    * If the SDK key doesn't contain the event ingestion hostname, or it's invalid, it returns null.
    */
   decodeEventIngestionUrl(sdkKey: string): string | null {
+    return this.decodeHostnames(sdkKey, EVENT_INGESTION_PATH).eventIngestionHostname;
+  }
+
+  /**
+   * Decodes and returns the configuration hostname from the provided Eppo SDK key string.
+   * If the SDK key doesn't contain the configuration hostname, or it's invalid, it returns null.
+   */
+  decodeAssignmentConfigurationUrl(sdkKey: string): string | null {
+    return this.decodeHostnames(sdkKey, ASSIGNMENT_CONFIG_PATH).configurationHostname;
+  }
+
+  /**
+   * Decodes and returns the edge configuration hostname from the provided Eppo SDK key string.
+   * If the SDK key doesn't contain the edge configuration hostname, or it's invalid, it returns null.
+   */
+  decodeEdgeConfigurationUrl(sdkKey: string): string | null {
+    return this.decodeHostnames(sdkKey, EDGE_CONFIG_PATH).configurationHostname;
+  }
+
+  private decodeHostnames(
+    sdkKey: string,
+    path: string,
+  ): {
+    eventIngestionHostname: string | null;
+    configurationHostname: string | null;
+  } {
     const encodedPayload = sdkKey.split('.')[1];
-    if (!encodedPayload) return null;
+    if (!encodedPayload) return { eventIngestionHostname: null, configurationHostname: null };
 
     const decodedPayload = Base64.decode(encodedPayload);
     const params = new URLSearchParams(decodedPayload);
-    const hostname = params.get('eh');
-    if (!hostname) return null;
+    const eventIngestionHostname = params.get(EVENT_INGESTION_HOSTNAME_KEY);
+    const configurationHostname = params.get(CONFIGURATION_HOSTNAME_KEY);
 
-    const hostAndPath = hostname.endsWith('/') ? `${hostname}${PATH}` : `${hostname}/${PATH}`;
-    if (!hostAndPath.startsWith('http://') && !hostAndPath.startsWith('https://')) {
-      // prefix hostname with https scheme if none present
-      return `https://${hostAndPath}`;
-    } else {
-      return hostAndPath;
+    return {
+      eventIngestionHostname: eventIngestionHostname
+        ? this.ensureHttps(this.ensurePath(eventIngestionHostname, path))
+        : null,
+      configurationHostname: configurationHostname
+        ? this.ensureHttps(this.ensurePath(configurationHostname, path))
+        : null,
+    };
+  }
+
+  private ensureHttps(hostname: string): string {
+    if (!hostname.startsWith('http://') && !hostname.startsWith('https://')) {
+      return `https://${hostname}`;
     }
+    return hostname;
+  }
+
+  private ensurePath(hostname: string, path: string): string {
+    return hostname.endsWith('/') ? `${hostname}${path}` : `${hostname}/${path}`;
   }
 }


### PR DESCRIPTION
… (FF-4143)

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

🎫 https://linear.app/eppo/issue/FF-4143/add-support-for-js-commons-to-decode-per-sdk-key-host

To add support for off-boarding customers from both the assignment and edge configuration APIs, we will be encoding a company specific hostname into key. Please see associated design doc for further details.

There will be 3 generations of SDKs "in the wild":

* Those without any hostname encoding (majority at this time)
* Containing an event ingestion hostname encoding (all created after November 2024)
* Future created with both an event ingestion and configuration hostname (after related server changes are merged)

We need to augment the existing decoder class to handle the new cases and support existing ones.

## Description
[//]: # (Describe your changes in detail)

* Adds two new public methods to `SdkDecoder`: `decodeAssignmentConfigurationUrl` and `decodeEdgeConfigurationUrl`. These will be used by the rules-based client and precomputed client, respectively. Those changes are not in scope for this PR.
* Refactored into a re-usable method `decodeHostnames`

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

New unit tests handling the 3 generations of SDK encodings.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
