### PR TITLE
fix: simplify `isObfuscated` messaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.14.2",
+  "version": "4.14.3",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -155,7 +155,8 @@ export default class EppoClient {
 
     if (isObfuscated !== undefined) {
       logger.info(
-        `[Eppo SDK] specifying isObfuscated no longer has an effect; obfuscation is inferred from the configuration.`,
+        '[Eppo SDK] specifying isObfuscated no longer has an effect and will be removed in the next major release; obfuscation ' +
+          'is now inferred from the configuration, so you can safely remove the option.',
       );
     }
   }
@@ -256,7 +257,8 @@ export default class EppoClient {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setIsObfuscated(isObfuscated: boolean) {
     logger.info(
-      '[Eppo SDK] setIsObfuscated no longer has an effect; obfuscation is inferred from the configuration.',
+      '[Eppo SDK] setIsObfuscated no longer has an effect and will be removed in the next major release; obfuscation ' +
+        'is now inferred from the configuration, so you can safely remove the call to this method.',
     );
   }
 

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -154,7 +154,7 @@ export default class EppoClient {
     this.configurationRequestParameters = configurationRequestParameters;
 
     if (isObfuscated !== undefined) {
-      logger.info(
+      logger.warn(
         '[Eppo SDK] specifying isObfuscated no longer has an effect and will be removed in the next major release; obfuscation ' +
           'is now inferred from the configuration, so you can safely remove the option.',
       );
@@ -256,7 +256,7 @@ export default class EppoClient {
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setIsObfuscated(isObfuscated: boolean) {
-    logger.info(
+    logger.warn(
       '[Eppo SDK] setIsObfuscated no longer has an effect and will be removed in the next major release; obfuscation ' +
         'is now inferred from the configuration, so you can safely remove the call to this method.',
     );


### PR DESCRIPTION
## Motivation and Context

The deprecation of `isObfuscated` led to the desire to emit a warning when the SDK may be acting out of expected vis a vis _obfuscated_ state of the config. The implementation left a lot to be desired and had some bugs. 

## Changes
- Emit an _info_ level log when setting `isObfuscated`
- Drop all `isObfuscatedCache` and warning on mismatch
- bump patch version
- Also fix `EppoClientParameters` to have new `overrides` field and restore use of `EppoClientParameters` type in constructor. This was broken in #184 
