### PR TITLE
fix: Update configuration stores in `ConfigurationRequestor` when they are changed on the client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.14.3",
+  "version": "4.14.4",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -210,14 +210,7 @@ export default class EppoClient {
   setFlagConfigurationStore(flagConfigurationStore: IConfigurationStore<Flag | ObfuscatedFlag>) {
     this.flagConfigurationStore = flagConfigurationStore;
 
-    // Update the ConfigurationRequestor if it exists
-    if (this.configurationRequestor) {
-      this.configurationRequestor.setConfigurationStores(
-        this.flagConfigurationStore,
-        this.banditVariationConfigurationStore || null,
-        this.banditModelConfigurationStore || null,
-      );
-    }
+    this.maybeUpdateConfigRequestor();
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -226,14 +219,7 @@ export default class EppoClient {
   ) {
     this.banditVariationConfigurationStore = banditVariationConfigurationStore;
 
-    // Update the ConfigurationRequestor if it exists
-    if (this.configurationRequestor) {
-      this.configurationRequestor.setConfigurationStores(
-        this.flagConfigurationStore,
-        this.banditVariationConfigurationStore,
-        this.banditModelConfigurationStore || null,
-      );
-    }
+    this.maybeUpdateConfigRequestor();
   }
 
   /** Sets the EventDispatcher instance to use when tracking events with {@link track}. */
@@ -263,12 +249,16 @@ export default class EppoClient {
   ) {
     this.banditModelConfigurationStore = banditModelConfigurationStore;
 
+    this.maybeUpdateConfigRequestor();
+  }
+
+  private maybeUpdateConfigRequestor() {
     // Update the ConfigurationRequestor if it exists
     if (this.configurationRequestor) {
       this.configurationRequestor.setConfigurationStores(
         this.flagConfigurationStore,
         this.banditVariationConfigurationStore || null,
-        this.banditModelConfigurationStore,
+        this.banditModelConfigurationStore || null,
       );
     }
   }

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -209,6 +209,15 @@ export default class EppoClient {
   // noinspection JSUnusedGlobalSymbols
   setFlagConfigurationStore(flagConfigurationStore: IConfigurationStore<Flag | ObfuscatedFlag>) {
     this.flagConfigurationStore = flagConfigurationStore;
+
+    // Update the ConfigurationRequestor if it exists
+    if (this.configurationRequestor) {
+      this.configurationRequestor.setConfigurationStores(
+        this.flagConfigurationStore,
+        this.banditVariationConfigurationStore || null,
+        this.banditModelConfigurationStore || null,
+      );
+    }
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -216,6 +225,15 @@ export default class EppoClient {
     banditVariationConfigurationStore: IConfigurationStore<BanditVariation[]>,
   ) {
     this.banditVariationConfigurationStore = banditVariationConfigurationStore;
+
+    // Update the ConfigurationRequestor if it exists
+    if (this.configurationRequestor) {
+      this.configurationRequestor.setConfigurationStores(
+        this.flagConfigurationStore,
+        this.banditVariationConfigurationStore,
+        this.banditModelConfigurationStore || null,
+      );
+    }
   }
 
   /** Sets the EventDispatcher instance to use when tracking events with {@link track}. */
@@ -244,6 +262,15 @@ export default class EppoClient {
     banditModelConfigurationStore: IConfigurationStore<BanditParameters>,
   ) {
     this.banditModelConfigurationStore = banditModelConfigurationStore;
+
+    // Update the ConfigurationRequestor if it exists
+    if (this.configurationRequestor) {
+      this.configurationRequestor.setConfigurationStores(
+        this.flagConfigurationStore,
+        this.banditVariationConfigurationStore || null,
+        this.banditModelConfigurationStore,
+      );
+    }
   }
 
   // noinspection JSUnusedGlobalSymbols

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -210,7 +210,7 @@ export default class EppoClient {
   setFlagConfigurationStore(flagConfigurationStore: IConfigurationStore<Flag | ObfuscatedFlag>) {
     this.flagConfigurationStore = flagConfigurationStore;
 
-    this.maybeUpdateConfigRequestor();
+    this.updateConfigRequestorIfExists();
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -219,7 +219,7 @@ export default class EppoClient {
   ) {
     this.banditVariationConfigurationStore = banditVariationConfigurationStore;
 
-    this.maybeUpdateConfigRequestor();
+    this.updateConfigRequestorIfExists();
   }
 
   /** Sets the EventDispatcher instance to use when tracking events with {@link track}. */
@@ -249,10 +249,10 @@ export default class EppoClient {
   ) {
     this.banditModelConfigurationStore = banditModelConfigurationStore;
 
-    this.maybeUpdateConfigRequestor();
+    this.updateConfigRequestorIfExists();
   }
 
-  private maybeUpdateConfigRequestor() {
+  private updateConfigRequestorIfExists() {
     // Update the ConfigurationRequestor if it exists
     if (this.configurationRequestor) {
       this.configurationRequestor.setConfigurationStores(

--- a/src/configuration-requestor.spec.ts
+++ b/src/configuration-requestor.spec.ts
@@ -15,7 +15,7 @@ import FetchHttpClient, {
   IUniversalFlagConfigResponse,
 } from './http-client';
 import { StoreBackedConfiguration } from './i-configuration';
-import { BanditParameters, BanditVariation, Flag } from './interfaces';
+import { BanditParameters, BanditVariation, Flag, VariationType } from './interfaces';
 
 describe('ConfigurationRequestor', () => {
   let flagStore: IConfigurationStore<Flag>;
@@ -639,6 +639,73 @@ describe('ConfigurationRequestor', () => {
 
         // Should only have one additional fetch (the UFC) and not the bandit parameters
         // expect(fetchSpy.mock.calls.length).toBe(initialFetchCount + 1);
+      });
+    });
+
+    describe('IConfigurationStore updates', () => {
+      it('should update configuration when stores are changed', async () => {
+        // Create new stores
+        const newFlagStore = new MemoryOnlyConfigurationStore<Flag>();
+        const newBanditVariationStore = new MemoryOnlyConfigurationStore<BanditVariation[]>();
+        const newBanditModelStore = new MemoryOnlyConfigurationStore<BanditParameters>();
+
+        // Add a test flag to the new flag store
+        await newFlagStore.setEntries({
+          'test-flag': {
+            key: 'test-flag',
+            enabled: true,
+            variationType: VariationType.STRING,
+            variations: {
+              control: { key: 'control', value: 'control-value' },
+              treatment: { key: 'treatment', value: 'treatment-value' },
+            },
+            allocations: [
+              {
+                key: 'allocation-1',
+                rules: [],
+                splits: [
+                  {
+                    shards: [{ salt: '', ranges: [{ start: 0, end: 10000 }] }],
+                    variationKey: 'treatment',
+                  },
+                ],
+                doLog: true,
+              },
+            ],
+            totalShards: 10000,
+          },
+        });
+
+        await newBanditModelStore.setEntries({
+          'test-bandit': {
+            banditKey: 'test-bandt',
+            modelVersion: 'v123',
+            modelName: 'falcon',
+            modelData: {
+              coefficients: {},
+              gamma: 0,
+              defaultActionScore: 0,
+              actionProbabilityFloor: 0,
+            },
+          },
+        });
+
+        // Get the configuration and verify it has the test flag
+        const initialConfig = configurationRequestor.getConfiguration();
+        expect(initialConfig.getFlagKeys()).toEqual([]);
+        expect(Object.keys(initialConfig.getBandits())).toEqual([]);
+
+        // Update the stores
+        configurationRequestor.setConfigurationStores(
+          newFlagStore,
+          newBanditVariationStore,
+          newBanditModelStore,
+        );
+
+        // Get the configuration and verify it has the test flag
+        const config = configurationRequestor.getConfiguration();
+        expect(config.getFlagKeys()).toEqual(['test-flag']);
+        expect(Object.keys(config.getBandits())).toEqual(['test-bandit']);
       });
     });
   });

--- a/src/configuration-requestor.ts
+++ b/src/configuration-requestor.ts
@@ -10,16 +10,34 @@ import { BanditVariation, BanditParameters, Flag, BanditReference } from './inte
 // Requests AND stores flag configurations
 export default class ConfigurationRequestor {
   private banditModelVersions: string[] = [];
-  private readonly configuration: StoreBackedConfiguration;
+  private configuration: StoreBackedConfiguration;
 
   constructor(
     private readonly httpClient: IHttpClient,
-    private readonly flagConfigurationStore: IConfigurationStore<Flag>,
-    private readonly banditVariationConfigurationStore: IConfigurationStore<
-      BanditVariation[]
-    > | null,
-    private readonly banditModelConfigurationStore: IConfigurationStore<BanditParameters> | null,
+    private flagConfigurationStore: IConfigurationStore<Flag>,
+    private banditVariationConfigurationStore: IConfigurationStore<BanditVariation[]> | null,
+    private banditModelConfigurationStore: IConfigurationStore<BanditParameters> | null,
   ) {
+    this.configuration = new StoreBackedConfiguration(
+      this.flagConfigurationStore,
+      this.banditVariationConfigurationStore,
+      this.banditModelConfigurationStore,
+    );
+  }
+
+  /**
+   * Updates the configuration stores and recreates the StoreBackedConfiguration
+   */
+  public setConfigurationStores(
+    flagConfigurationStore: IConfigurationStore<Flag>,
+    banditVariationConfigurationStore: IConfigurationStore<BanditVariation[]> | null,
+    banditModelConfigurationStore: IConfigurationStore<BanditParameters> | null,
+  ): void {
+    this.flagConfigurationStore = flagConfigurationStore;
+    this.banditVariationConfigurationStore = banditVariationConfigurationStore;
+    this.banditModelConfigurationStore = banditModelConfigurationStore;
+
+    // Recreate the configuration with the new stores
     this.configuration = new StoreBackedConfiguration(
       this.flagConfigurationStore,
       this.banditVariationConfigurationStore,


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes FF-4161

## Motivation and Context
Not updating the Config Stores on the Config Requestor means that the dev can call `setFlagConfigurationStore` without any effect. This actually causes test failures downstream where we are using and abusing the same client instance for all the tests.

**This bug is blocking integrating the latest common downstream.**

## Description
- allow config stores to be updated on the Config Requestor.

## How has this been tested?
- new unit tests
- verified to fix downstream testing failures

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
