### PR TITLE
feat: use subdomain in precomputed client

### DIFF
--- a/src/client/eppo-precomputed-client.spec.ts
+++ b/src/client/eppo-precomputed-client.spec.ts
@@ -714,6 +714,78 @@ describe('EppoPrecomputedClient E2E test', () => {
         pollAfterFailedInitialization ? red : 'default',
       );
     });
+
+    describe('Enhanced SDK Token with encoded subdomain', () => {
+      let urlsRequested: string[] = [];
+
+      beforeEach(() => {
+        urlsRequested = [];
+        global.fetch = jest.fn((url) => {
+          urlsRequested.push(url.toString());
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(precomputedResponse),
+          } as Response);
+        });
+      });
+
+      it('should request from the encoded subdomain', async () => {
+        const client = new EppoPrecomputedClient({
+          precomputedFlagStore: new MemoryOnlyConfigurationStore<PrecomputedFlag>(),
+          subject,
+          requestParameters: {
+            apiKey: 'zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA==', // subdomain=experiment
+            sdkName: 'js-client-sdk-common',
+            sdkVersion: '1.0.0',
+          },
+        });
+
+        await client.fetchPrecomputedFlags();
+
+        expect(urlsRequested).toHaveLength(1);
+        expect(urlsRequested[0]).toContain(
+          'https://experiment.fs-edge-assignment.eppo.cloud/assignments?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D&sdkName=js-client-sdk-common&sdkVersion=1.0.0',
+        );
+      });
+
+      it('should request from the default domain if the encoded subdomain is not present', async () => {
+        const client = new EppoPrecomputedClient({
+          precomputedFlagStore: new MemoryOnlyConfigurationStore<PrecomputedFlag>(),
+          subject,
+          requestParameters: {
+            apiKey: 'old style key',
+            sdkName: 'js-client-sdk-common',
+            sdkVersion: '1.0.0',
+          },
+        });
+
+        await client.fetchPrecomputedFlags();
+
+        expect(urlsRequested).toHaveLength(1);
+        expect(urlsRequested[0]).toEqual(
+          'https://fs-edge-assignment.eppo.cloud/assignments?apiKey=old+style+key&sdkName=js-client-sdk-common&sdkVersion=1.0.0',
+        );
+      });
+
+      it('should request from the provided baseUrl if present', async () => {
+        const client = new EppoPrecomputedClient({
+          precomputedFlagStore: new MemoryOnlyConfigurationStore<PrecomputedFlag>(),
+          subject,
+          requestParameters: {
+            apiKey: 'zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA==', // subdomain=experiment
+            sdkName: 'js-client-sdk-common',
+            sdkVersion: '1.0.0',
+            baseUrl: 'https://custom-base-url.com',
+          },
+        });
+
+        await client.fetchPrecomputedFlags();
+
+        expect(urlsRequested).toHaveLength(1);
+        expect(urlsRequested[0]).toContain('https://custom-base-url.com');
+      });
+    });
   });
 
   describe('Obfuscated precomputed flags', () => {

--- a/src/client/eppo-precomputed-client.ts
+++ b/src/client/eppo-precomputed-client.ts
@@ -32,6 +32,7 @@ import {
 import { getMD5Hash } from '../obfuscation';
 import initPoller, { IPoller } from '../poller';
 import PrecomputedRequestor from '../precomputed-requestor';
+import SdkTokenDecoder from '../sdk-token-decoder';
 import { Attributes, ContextAttributes, FlagKey } from '../types';
 import { validateNotBlank } from '../validation';
 import { LIB_VERSION } from '../version';
@@ -164,6 +165,7 @@ export default class EppoPrecomputedClient {
       defaultUrl: PRECOMPUTED_BASE_URL,
       baseUrl,
       queryParams: { apiKey, sdkName, sdkVersion },
+      sdkTokenDecoder: new SdkTokenDecoder(apiKey),
     });
     const httpClient = new FetchHttpClient(apiEndpoints, requestTimeoutMs);
     const precomputedRequestor = new PrecomputedRequestor(


### PR DESCRIPTION
## Motivation and Context
Using the `SdkTokenDecoder` to determine the request URL for precomputed assignments was missed in #263 

