### PR TITLE
Update automated tests to also check evaluation details

### DIFF
--- a/src/client/eppo-client-assignment-details.spec.ts
+++ b/src/client/eppo-client-assignment-details.spec.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 
 import {
+  AssignmentVariationValue,
   IAssignmentTestCase,
   MOCK_UFC_RESPONSE_FILE,
   readMockUFCResponse,
@@ -328,8 +329,8 @@ describe('EppoClient get*AssignmentDetails', () => {
                 flagKey: string,
                 subjectKey: string,
                 subjectAttributes: Record<string, AttributeType>,
-                defaultValue: boolean | string | number | object,
-              ) => IAssignmentDetails<boolean | string | number | object>;
+                defaultValue: AssignmentVariationValue,
+              ) => IAssignmentDetails<AssignmentVariationValue>;
               if (!assignmentFn) {
                 throw new Error(`Unknown variation type: ${variationType}`);
               }

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -386,7 +386,7 @@ describe('EppoClient E2E test', () => {
           assignmentFn,
         );
 
-        validateTestAssignments(assignments, flag, assignmentWithDetails);
+        validateTestAssignments(assignments, flag, assignmentWithDetails, isObfuscated);
       });
     });
   });

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -4,6 +4,7 @@ import * as td from 'testdouble';
 
 import {
   ASSIGNMENT_TEST_DATA_DIR,
+  AssignmentVariationValue,
   getTestAssignments,
   IAssignmentTestCase,
   MOCK_UFC_RESPONSE_FILE,
@@ -28,7 +29,11 @@ import { Flag, ObfuscatedFlag, VariationType, FormatEnum, Variation } from '../i
 import { getMD5Hash } from '../obfuscation';
 import { AttributeType } from '../types';
 
-import EppoClient, { checkTypeMatch, FlagConfigurationRequestParameters } from './eppo-client';
+import EppoClient, {
+  checkTypeMatch,
+  FlagConfigurationRequestParameters,
+  IAssignmentDetails,
+} from './eppo-client';
 import { initConfiguration } from './test-utils';
 
 // Use a known salt to produce deterministic hashes
@@ -352,7 +357,7 @@ describe('EppoClient E2E test', () => {
 
         let assignments: {
           subject: SubjectTestCase;
-          assignment: string | boolean | number | null | object;
+          assignment: AssignmentVariationValue;
         }[] = [];
 
         const typeAssignmentFunctions = assignmentWithDetails
@@ -375,8 +380,8 @@ describe('EppoClient E2E test', () => {
           flagKey: string,
           subjectKey: string,
           subjectAttributes: Record<string, AttributeType>,
-          defaultValue: boolean | string | number | object,
-        ) => never;
+          defaultValue: AssignmentVariationValue,
+        ) => AssignmentVariationValue | IAssignmentDetails<AssignmentVariationValue>;
         if (!assignmentFn) {
           throw new Error(`Unknown variation type: ${variationType}`);
         }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -144,7 +144,6 @@ export class Evaluator {
         configDetails.configFormat,
       );
     } catch (err: any) {
-      console.error('>>>>', err);
       const flagEvaluationDetails = flagEvaluationDetailsBuilder.gracefulBuild(
         'ASSIGNMENT_ERROR',
         `Assignment Error: ${err.message}`,

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -43,6 +43,7 @@ export interface IUniversalFlagConfigResponse {
 }
 
 export interface IBanditParametersResponse {
+  createdAt: string; // ISO formatted string
   bandits: Record<string, BanditParameters>;
 }
 

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -43,7 +43,7 @@ export interface IUniversalFlagConfigResponse {
 }
 
 export interface IBanditParametersResponse {
-  createdAt: string; // ISO formatted string
+  updatedAt: string; // ISO formatted string
   bandits: Record<string, BanditParameters>;
 }
 

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -159,7 +159,10 @@ export function validateTestAssignments(
 
     expect(assignedVariation).toEqual(subject.assignment);
 
-    if (withDetails && assignmentDetails) {
+    if (withDetails) {
+      if (!assignmentDetails) {
+        throw new Error('Expected assignmentDetails to be populated');
+      }
       expect(assignmentDetails.environmentName).toBe(subject.evaluationDetails.environmentName);
       expect(assignmentDetails.flagEvaluationCode).toBe(
         subject.evaluationDetails.flagEvaluationCode,

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -113,7 +113,9 @@ export function getTestAssignments(
   return assignments;
 }
 
-const configCreatedAt = readMockUFCResponse(MOCK_UFC_RESPONSE_FILE).createdAt;
+const configCreatedAt = (
+  readMockUFCResponse(MOCK_UFC_RESPONSE_FILE) as IUniversalFlagConfigResponse
+).createdAt;
 const testHelperInstantiationDate = new Date();
 
 export function validateTestAssignments(


### PR DESCRIPTION
_Eppo Internal:_
🎟️ [FF-4335 - Update JS Common Tests for Evaluation Details](https://linear.app/eppo/issue/FF-4335/update-js-common-tests-for-evaluation-details)

## Motivation and Context
Our JavaScript SDKs have `getXXXXXXXDetails()` methods, so we should ensure the details are being correctly populated.

## Description
Expand `eppo-client.spec.ts` to include checking details by using data providers.

## How has this been documented?
(no documentation needed for adding tests)

## How has this been tested?
This _is_ the tests 😛 