### PR TITLE
fix(poller): correctly allow cancellation of timeouts after the first one

### DIFF
--- a/src/poller.ts
+++ b/src/poller.ts
@@ -137,7 +137,7 @@ export default function initPoller(
       }
     }
 
-    setTimeout(poll, nextPollMs);
+    nextTimer = setTimeout(poll, nextPollMs);
   }
 
   return {


### PR DESCRIPTION
The `stop` method cancels the timeout stored in `nextTimer` if it's set but we were only initializing it the first time we set the timeout, not for any subsequent ones. The `stopped` flag means that `callback` was not called, but this can still cause a memory leak and delay shutdown of the Node process.

Assigning each timeout to the nextTimer variable ensures that the clearTimeout call works correctly to invalidate the timeout that has been set.

Tested locally in a larger project that getInstance().stopPolling() allows a Node server to shut down successfully, versus before it would wait up to 30 seconds until the next scheduled poll.

---
labels: mergeable, bugfix
---