### PR TITLE
Fix browser logging fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.15.2",
+  "version": "4.15.3",
   "description": "Common library for Eppo JavaScript SDKs (web, react native, and node)",
   "main": "dist/index.js",
   "files": [

--- a/src/application-logger.ts
+++ b/src/application-logger.ts
@@ -4,8 +4,15 @@ export const loggerPrefix = '[Eppo SDK]';
 
 // Create a Pino logger instance
 export const logger = pino({
-  // eslint-disable-next-line no-restricted-globals
-  level: process.env.LOG_LEVEL ?? (process.env.NODE_ENV === 'production' ? 'warn' : 'info'),
-  // https://getpino.io/#/docs/browser
-  browser: { disabled: true },
+  // Use any specified log level, or warn in production, info otherwise
+  level:
+    /* eslint-disable no-restricted-globals */
+    typeof process !== 'undefined' && process.env.LOG_LEVEL
+      ? process.env.LOG_LEVEL
+      : typeof process !== 'undefined' && process.env.NODE_ENV === 'production'
+        ? 'warn'
+        : 'info',
+  /* eslint-enable no-restricted-globals */
+
+  browser: { disabled: true }, // See https://getpino.io/#/docs/browser
 });

--- a/src/application-logger.ts
+++ b/src/application-logger.ts
@@ -5,8 +5,8 @@ export const loggerPrefix = '[Eppo SDK]';
 // Create a Pino logger instance
 export const logger = pino({
   // Use any specified log level, or warn in production/browser, info otherwise
+  /* eslint-disable no-restricted-globals */
   level:
-    /* eslint-disable no-restricted-globals */
     typeof process !== 'undefined' && process.env.LOG_LEVEL
       ? process.env.LOG_LEVEL
       : typeof process === 'undefined' || process.env.NODE_ENV === 'production'

--- a/src/application-logger.ts
+++ b/src/application-logger.ts
@@ -4,12 +4,12 @@ export const loggerPrefix = '[Eppo SDK]';
 
 // Create a Pino logger instance
 export const logger = pino({
-  // Use any specified log level, or warn in production, info otherwise
+  // Use any specified log level, or warn in production/browser, info otherwise
   level:
     /* eslint-disable no-restricted-globals */
     typeof process !== 'undefined' && process.env.LOG_LEVEL
       ? process.env.LOG_LEVEL
-      : typeof process !== 'undefined' && process.env.NODE_ENV === 'production'
+      : typeof process === 'undefined' || process.env.NODE_ENV === 'production'
         ? 'warn'
         : 'info',
   /* eslint-enable no-restricted-globals */

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -756,14 +756,14 @@ export default class EppoClient {
 
         try {
           this.logBanditAction(banditEvent);
-        } catch (err: any) {
-          logger.error(err, 'Error logging bandit event');
+        } catch (err) {
+          logger.error({ err }, 'Error logging bandit event');
         }
 
         evaluationDetails.banditAction = action;
       }
     } catch (err: any) {
-      logger.error(err, 'Error determining bandit action');
+      logger.error({ err }, 'Error determining bandit action');
       if (!this.isGracefulFailureMode) {
         throw err;
       }
@@ -772,7 +772,7 @@ export default class EppoClient {
         // Update the flag evaluation code to indicate that
         evaluationDetails.flagEvaluationCode = 'BANDIT_ERROR';
       }
-      evaluationDetails.flagEvaluationDescription = `Error evaluating bandit action: ${err.message}`;
+      evaluationDetails.flagEvaluationDescription = `Error evaluating bandit action: ${err?.message}`;
     }
     return { variation, action, evaluationDetails };
   }
@@ -877,7 +877,7 @@ export default class EppoClient {
       // Record in the assignment cache, if active, to deduplicate subsequent repeat assignments
       this.banditAssignmentCache?.set(banditAssignmentCacheProperties);
     } catch (err) {
-      logger.warn(err, 'Error encountered logging bandit action');
+      logger.warn({ err }, 'Error encountered logging bandit action');
     }
   }
 

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -757,13 +757,13 @@ export default class EppoClient {
         try {
           this.logBanditAction(banditEvent);
         } catch (err: any) {
-          logger.error('Error logging bandit event', err);
+          logger.error(err, 'Error logging bandit event');
         }
 
         evaluationDetails.banditAction = action;
       }
     } catch (err: any) {
-      logger.error('Error determining bandit action', err);
+      logger.error(err, 'Error determining bandit action');
       if (!this.isGracefulFailureMode) {
         throw err;
       }
@@ -877,7 +877,7 @@ export default class EppoClient {
       // Record in the assignment cache, if active, to deduplicate subsequent repeat assignments
       this.banditAssignmentCache?.set(banditAssignmentCacheProperties);
     } catch (err) {
-      logger.warn('Error encountered logging bandit action', err);
+      logger.warn(err, 'Error encountered logging bandit action');
     }
   }
 

--- a/src/client/eppo-precomputed-client.ts
+++ b/src/client/eppo-precomputed-client.ts
@@ -519,7 +519,7 @@ export default class EppoPrecomputedClient {
       // Record in the assignment cache, if active, to deduplicate subsequent repeat assignments
       this.banditAssignmentCache?.set(banditAssignmentCacheProperties);
     } catch (err) {
-      logger.warn('Error encountered logging bandit action', err);
+      logger.warn(err, 'Error encountered logging bandit action');
     }
   }
 

--- a/src/client/eppo-precomputed-client.ts
+++ b/src/client/eppo-precomputed-client.ts
@@ -519,7 +519,7 @@ export default class EppoPrecomputedClient {
       // Record in the assignment cache, if active, to deduplicate subsequent repeat assignments
       this.banditAssignmentCache?.set(banditAssignmentCacheProperties);
     } catch (err) {
-      logger.warn(err, 'Error encountered logging bandit action');
+      logger.warn({ err }, 'Error encountered logging bandit action');
     }
   }
 

--- a/src/events/event-delivery.ts
+++ b/src/events/event-delivery.ts
@@ -33,8 +33,8 @@ export default class EventDelivery implements IEventDelivery {
       } else {
         return { failedEvents: batch };
       }
-    } catch (e: any) {
-      logger.warn(e, `Failed to upload event batch`);
+    } catch (err) {
+      logger.warn({ err }, `Failed to upload event batch`);
       return { failedEvents: batch };
     }
   }

--- a/src/events/event-delivery.ts
+++ b/src/events/event-delivery.ts
@@ -34,7 +34,7 @@ export default class EventDelivery implements IEventDelivery {
         return { failedEvents: batch };
       }
     } catch (e: any) {
-      logger.warn(`Failed to upload event batch`, e);
+      logger.warn(e, `Failed to upload event batch`);
       return { failedEvents: batch };
     }
   }


### PR DESCRIPTION
👯  Related PR: [`js-client-sdk #257`](https://github.com/Eppo-exp/js-client-sdk/pull/257#pullrequestreview-3302101524)

_Eppo Only:_
🎟️ **Tickets:**
* [FFL-780 - Don't assume process (and process.env) exists in js-sdk-common application logger](https://datadoghq.atlassian.net/browse/FFL-780)
* [FFESUPPORT-100 - Legacy Eppo Browser SDK has browser logging hard-coded off](https://datadoghq.atlassian.net/browse/FFESUPPORT-100)

## Motivation and Context
This common repository is shared with the Node.js and Browser JavaScript SDKs. The latter won't have a global `process`, causing errors unless a dummy global `process` is defined.

Also, currently, logging is hard-coded to be off (silent) for the Browser SDK. However, having logs can be helpful, especially for debugging.

## Description
This PR does not assume `process` will be defined.

It also changes the logger's default log level for browser to be `warn` instead of forced off. There is a new `setLogLevel()` method that can be called to change that if desired.

## How has this been documented?
* [`eppo-docs #698` - Documentation for setLogLevel()](https://github.com/Eppo-exp/eppo-docs/pull/698)

## How has this been tested?
* Existing unit tests
* Spun up sample browser app that worked without a dummy `process`. Also I saw no logs by default, error if I provided a bad SDK key, and then all the info logs if I changed the log level on purpose.

<img width="1165" height="762" alt="image" src="https://github.com/user-attachments/assets/4b2ae962-4533-4fdf-95d2-d4685fd50438" />
